### PR TITLE
Fix photo handler await

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -940,7 +940,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
 
         # 3. Ждать окончания run
         while run.status not in ("completed", "failed", "cancelled", "expired"):
-            time.sleep(2)
+            await asyncio.sleep(2)
             run = client.beta.threads.runs.retrieve(thread_id=run.thread_id, run_id=run.id)
 
         if run.status != "completed":


### PR DESCRIPTION
## Summary
- handle async sleeps correctly for photo handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685e4d65e478832a81e7f7550ce03687