### PR TITLE
[repo] Ignore pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ photos/
 
 # Temporary/test files
 test123.txt
+.pytest_cache/


### PR DESCRIPTION
## Summary
- update `.gitignore` to exclude `.pytest_cache/`

## Testing
- `pytest tests/` *(fails: No module named 'matplotlib')*
- `flake8 diabetes/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd6457858832abcf02bbb766717c7