### PR TITLE
[reporting] remove unused import

### DIFF
--- a/diabetes/reporting.py
+++ b/diabetes/reporting.py
@@ -7,7 +7,6 @@ from reportlab.pdfgen import canvas
 from reportlab.lib.units import mm
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
-from reportlab.pdfbase.pdfmetrics import stringWidth
 import textwrap
 
 # Регистрация шрифтов для поддержки кириллицы и жирного начертания


### PR DESCRIPTION
## Summary
- clean up unused import in `reporting.py`

## Testing
- `flake8 diabetes/` *(fails: command not found)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687fd7d228b0832aa49aa03e277f94f1