### PR TITLE
[handlers] remove duplicate doc_handler

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -330,21 +330,6 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 await query.edit_message_text("\n".join(txt), parse_mode="Markdown")
                 return
 
-async def doc_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    document = update.message.document
-    if not document or not document.mime_type.startswith("image/"):
-        return ConversationHandler.END
-
-    user_id = update.effective_user.id
-    ext      = Path(document.file_name).suffix or ".jpg"
-    file_path = f"photos/{user_id}_{document.file_unique_id}{ext}"
-    os.makedirs("photos", exist_ok=True)
-    file = await context.bot.get_file(document.file_id)
-    await file.download_to_drive(file_path)
-
-    # записываем путь и вызовем photo_handler
-    context.user_data["__file_path"] = file_path
-    return await photo_handler(update, context, demo=False)
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     context.user_data.clear()


### PR DESCRIPTION
## Summary
- remove the earlier `doc_handler` implementation and keep the later version

## Testing
- `flake8 diabetes/` *(fails: E221, W291, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff28804ac832aa99ef220b00abec7