### PR TITLE
[handlers] remove unused imports and vars

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -11,20 +11,18 @@ from pathlib import Path
 
 
 from telegram.ext import (
-    ApplicationBuilder, CommandHandler, MessageHandler, CallbackQueryHandler,
+    CommandHandler, MessageHandler, CallbackQueryHandler,
     ConversationHandler, ContextTypes, filters,
 )
 
 from sqlalchemy import func
 
-from diabetes.config import TELEGRAM_TOKEN, OPENAI_PROXY
-from diabetes.db import SessionLocal, init_db, User, Profile, Entry
+from diabetes.db import SessionLocal, User, Profile, Entry
 from diabetes.functions import (
     PatientProfile, calc_bolus, extract_nutrition_info,
 )
 from diabetes.gpt_client import create_thread, send_message, client
 from diabetes.gpt_command_parser import parse_command
-from diabetes.reporting import make_sugar_plot, generate_pdf_report
 
 from diabetes.ui import menu_keyboard, dose_keyboard, confirm_keyboard
 
@@ -468,12 +466,10 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         cf = float(args[1])
         target = float(args[2])
 
-        # Флаги подозрения
-        suspicious = False
+        # Предупреждение, если параметры выглядят странно
         warning_msg = ""
 
         if icr > 8 or cf < 3:
-            suspicious = True
             warning_msg = (
                 "\n⚠️ Проверьте, пожалуйста: возможно, вы перепутали местами ИКХ и КЧ.\n"
                 f"• Вы ввели ИКХ = {icr} ммоль/л (высоковато)\n"
@@ -1062,7 +1058,6 @@ async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_T
         await query.edit_message_text("❌ Запрос отменён.", reply_markup=menu_keyboard)
         context.user_data.pop('awaiting_report_date', None)
         return
-    user_id = update.effective_user.id
     now = datetime.now()
     if data == "report_today":
         date_from = now.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1103,7 +1098,6 @@ async def report_date_input(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def send_report(update, context, date_from, period_label, query=None):
     user_id = update.effective_user.id
 
-    now = datetime.now()
     with SessionLocal() as s:
         entries = (
             s.query(Entry)

--- a/diabetes/reporting.py
+++ b/diabetes/reporting.py
@@ -96,7 +96,7 @@ def generate_pdf_report(summary_lines, errors, day_lines, gpt_text, plot_buf):
             img_reader = io.BytesIO(plot_buf.read())
             c.drawImage(img_reader, x_margin, y - 65*mm, width=160*mm, height=55*mm, preserveAspectRatio=True)
             y -= 65 * mm
-        except Exception as e:
+        except Exception:
             pass
 
     # Анализ и рекомендации


### PR DESCRIPTION
## Summary
- remove TELEGRAM_TOKEN and OPENAI_PROXY imports from `handlers.py`
- drop other unused imports
- clean up unused local variables in handlers and reporting

## Testing
- `flake8 diabetes`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff38b57ac832a9d60eb373eb8e256