### PR TITLE
[config,db] Clean spacing and imports

### DIFF
--- a/diabetes/config.py
+++ b/diabetes/config.py
@@ -4,16 +4,13 @@ from dotenv import load_dotenv
 
 load_dotenv()  # Загрузка переменных из .env файла
 
-TELEGRAM_TOKEN      = os.getenv('TELEGRAM_TOKEN')
-OPENAI_API_KEY      = os.getenv('OPENAI_API_KEY')
-OPENAI_ASSISTANT_ID = os.getenv('OPENAI_ASSISTANT_ID')  
-OPENAI_PROXY        = os.getenv('OPENAI_PROXY')
+TELEGRAM_TOKEN = os.getenv('TELEGRAM_TOKEN')
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+OPENAI_ASSISTANT_ID = os.getenv('OPENAI_ASSISTANT_ID')
+OPENAI_PROXY = os.getenv('OPENAI_PROXY')
 
-DB_HOST     = os.getenv('DB_HOST', 'localhost')
-DB_PORT     = os.getenv('DB_PORT', '5432')
-DB_NAME     = os.getenv('DB_NAME', 'diabetes_bot')
-DB_USER     = os.getenv('DB_USER', 'diabetes_user')
+DB_HOST = os.getenv('DB_HOST', 'localhost')
+DB_PORT = os.getenv('DB_PORT', '5432')
+DB_NAME = os.getenv('DB_NAME', 'diabetes_bot')
+DB_USER = os.getenv('DB_USER', 'diabetes_user')
 DB_PASSWORD = os.getenv('DB_PASSWORD', '')
-
-
-

--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -1,7 +1,5 @@
-# functions.py
 # db.py  ← полный и единственный источник моделей
 
-from datetime import datetime
 
 from sqlalchemy import (
     create_engine, Column, Integer, BigInteger, String,
@@ -13,11 +11,14 @@ from diabetes.config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
 
 
 # ────────────────── подключение к Postgres ──────────────────
-DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+DATABASE_URL = (
+    f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/"
+    f"{DB_NAME}"
+)
 
-engine       = create_engine(DATABASE_URL)
+engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(bind=engine)
-Base         = declarative_base()
+Base = declarative_base()
 
 
 # ───────────────────────── модели ────────────────────────────
@@ -25,36 +26,40 @@ class User(Base):
     __tablename__ = "users"
 
     telegram_id = Column(BigInteger, primary_key=True, index=True)
-    thread_id   = Column(String, nullable=False)
-    created_at  = Column(TIMESTAMP, server_default=func.now())
+    thread_id = Column(String, nullable=False)
+    created_at = Column(TIMESTAMP, server_default=func.now())
 
 
 class Profile(Base):
     __tablename__ = "profiles"
 
-    telegram_id = Column(BigInteger, ForeignKey("users.telegram_id"), primary_key=True)
-    icr         = Column(Float)   # г углеводов на 1 Е инсулина
-    cf          = Column(Float)   # коэффициент коррекции
-    target_bg   = Column(Float)   # целевой сахар
-    user        = relationship("User")
+    telegram_id = Column(
+        BigInteger,
+        ForeignKey("users.telegram_id"),
+        primary_key=True,
+    )
+    icr = Column(Float)  # г углеводов на 1 Е инсулина
+    cf = Column(Float)  # коэффициент коррекции
+    target_bg = Column(Float)  # целевой сахар
+    user = relationship("User")
 
 
 class Entry(Base):
     __tablename__ = "entries"
 
-    id          = Column(Integer, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True, index=True)
     telegram_id = Column(BigInteger, ForeignKey("users.telegram_id"))
 
-    event_time  = Column(TIMESTAMP, nullable=False)          # время приёма пищи / инъекции
-    created_at  = Column(TIMESTAMP, server_default=func.now())
-    updated_at  = Column(TIMESTAMP, onupdate=func.now())
+    event_time = Column(TIMESTAMP, nullable=False)  # время приёма
+    created_at = Column(TIMESTAMP, server_default=func.now())
+    updated_at = Column(TIMESTAMP, onupdate=func.now())
 
-    photo_path   = Column(String)
-    carbs_g      = Column(Float)
-    xe           = Column(Float)
+    photo_path = Column(String)
+    carbs_g = Column(Float)
+    xe = Column(Float)
     sugar_before = Column(Float)
-    dose         = Column(Float)
-    gpt_summary  = Column(Text)
+    dose = Column(Float)
+    gpt_summary = Column(Text)
 
 
 # ────────────────────── инициализация ────────────────────────


### PR DESCRIPTION
## Summary
- remove unused imports and comments from db.py
- fix extra spaces and trailing blank lines in config
- shorten overly long database lines
- eliminate multi-space alignment

## Testing
- `flake8 diabetes/config.py diabetes/db.py`
- `flake8 diabetes | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_687ff5ba8af0832aae2ddc5adc0407c4