### PR TITLE
[handlers] fix profile command field assignments

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -485,8 +485,8 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
             prof = Profile(telegram_id=user_id)
             session.add(prof)
 
-        prof.icr = cf  # г/ед
-        prof.cf = icr  # ммоль/л
+        prof.icr = icr  # г/ед
+        prof.cf = cf   # ммоль/л
         prof.target_bg = target
         session.commit()
         session.close()


### PR DESCRIPTION
## Summary
- correct `profile_command` assignments for ICR and CF values

## Testing
- `pytest -q`
- `flake8 diabetes` (fails: E501, E302, F821 and more)

------
https://chatgpt.com/codex/tasks/task_e_68805ab96724832a93f45d6e03a34264