### PR TITLE
[gpt] Respect OPENAI_PROXY flag

### DIFF
--- a/diabetes/gpt_client.py
+++ b/diabetes/gpt_client.py
@@ -6,8 +6,10 @@ import logging
 from diabetes.config import OPENAI_API_KEY, OPENAI_ASSISTANT_ID, OPENAI_PROXY
 
 # --- Только здесь прописываем прокси ---
-os.environ["HTTP_PROXY"]  = OPENAI_PROXY
-os.environ["HTTPS_PROXY"] = OPENAI_PROXY
+# Если переменная OPENAI_PROXY указана, выставляем HTTP(S)_PROXY
+if OPENAI_PROXY:
+    os.environ["HTTP_PROXY"] = OPENAI_PROXY
+    os.environ["HTTPS_PROXY"] = OPENAI_PROXY
 
 client = openai.OpenAI(api_key=OPENAI_API_KEY)
 

--- a/diabetes/gpt_command_parser.py
+++ b/diabetes/gpt_command_parser.py
@@ -3,8 +3,10 @@ from openai import OpenAI
 from diabetes.config import OPENAI_API_KEY, OPENAI_PROXY
 
 # 1️⃣ СРАЗУ ставим переменные окружения — до создания клиента!
-os.environ["HTTP_PROXY"]  = OPENAI_PROXY
-os.environ["HTTPS_PROXY"] = OPENAI_PROXY
+# Прокси активируется только если OPENAI_PROXY задан
+if OPENAI_PROXY:
+    os.environ["HTTP_PROXY"] = OPENAI_PROXY
+    os.environ["HTTPS_PROXY"] = OPENAI_PROXY
 
 # 2️⃣ Создаём обычный клиент OpenAI — без extra‑аргументов,
 #    он возьмёт прокси из env автоматически.


### PR DESCRIPTION
## Summary
- guard proxy initialization in `gpt_client` and `gpt_command_parser`
- document optional proxy usage

## Testing
- `flake8 diabetes | head -n 5` *(fails: E302, E501, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68807207d86c832aac16527236650866