### PR TITLE
Fix asynchronous sleep in bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -940,7 +940,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
 
         # 3. Ждать окончания run
         while run.status not in ("completed", "failed", "cancelled", "expired"):
-            time.sleep(2)
+            await asyncio.sleep(2)
             run = client.beta.threads.runs.retrieve(thread_id=run.thread_id, run_id=run.id)
 
         if run.status != "completed":


### PR DESCRIPTION
## Summary
- use `await asyncio.sleep` in `photo_handler`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891badeb60832a816c6dc530ad7998