### PR TITLE
Fix optional OpenAI proxy

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -6,8 +6,9 @@ import logging
 from config import OPENAI_API_KEY, OPENAI_ASSISTANT_ID, OPENAI_PROXY
 
 # --- Только здесь прописываем прокси ---
-os.environ["HTTP_PROXY"]  = OPENAI_PROXY
-os.environ["HTTPS_PROXY"] = OPENAI_PROXY
+if OPENAI_PROXY is not None:
+    os.environ["HTTP_PROXY"] = OPENAI_PROXY
+    os.environ["HTTPS_PROXY"] = OPENAI_PROXY
 
 client = openai.OpenAI(api_key=OPENAI_API_KEY)
 

--- a/gpt_command_parser.py
+++ b/gpt_command_parser.py
@@ -3,8 +3,9 @@ from openai import OpenAI
 from config import OPENAI_API_KEY, OPENAI_PROXY
 
 # 1️⃣ СРАЗУ ставим переменные окружения — до создания клиента!
-os.environ["HTTP_PROXY"]  = OPENAI_PROXY
-os.environ["HTTPS_PROXY"] = OPENAI_PROXY
+if OPENAI_PROXY is not None:
+    os.environ["HTTP_PROXY"] = OPENAI_PROXY
+    os.environ["HTTPS_PROXY"] = OPENAI_PROXY
 
 # 2️⃣ Создаём обычный клиент OpenAI — без extra‑аргументов,
 #    он возьмёт прокси из env автоматически.


### PR DESCRIPTION
## Summary
- set HTTP(S)_PROXY only when `OPENAI_PROXY` is defined in `gpt_client.py` and `gpt_command_parser.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68892e887770832abbb4c7204ce16cd1