### PR TITLE
Use real python-dotenv

### DIFF
--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -1,3 +1,0 @@
-def load_dotenv(*args, **kwargs):
-    pass
-


### PR DESCRIPTION
## Summary
- remove the local `dotenv` stub
- rely on `python-dotenv` so configuration variables load from `.env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688931fb9800832a85b51218b96301bd