### PR TITLE
Fix dependencies for report.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ typing-inspection==0.4.0
 typing_extensions==4.13.2
 fastapi==0.116.1
 flake8==7.0.0
+matplotlib==3.8.4
+reportlab==4.1.0


### PR DESCRIPTION
## Summary
- add `matplotlib` and `reportlab` to requirements for generating PDF reports

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688933319ddc832ab00c646ab3cf8586