### PR TITLE
Refactor bot handlers into package

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,16 +1,16 @@
-import logging
-from telegram.ext import ApplicationBuilder, CommandHandler, MessageHandler, CallbackQueryHandler, ConversationHandler, filters
+from telegram.ext import ApplicationBuilder, CommandHandler, MessageHandler, CallbackQueryHandler, filters
 
-from config import TELEGRAM_TOKEN, validate_tokens
-
-validate_tokens()
+from config import TELEGRAM_TOKEN
 from db import init_db
-from handlers import (
+from bot.startup import setup
+from bot.conversations import (
     onboarding_conv,
     sugar_conv,
     photo_conv,
     dose_conv,
     profile_conv,
+)
+from bot.handlers import (
     start,
     menu_handler,
     reset_handler,
@@ -26,8 +26,7 @@ from handlers import (
 )
 
 
-logging.basicConfig(format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO)
-logger = logging.getLogger("bot")
+logger = setup()
 
 
 def main() -> None:

--- a/bot/conversations.py
+++ b/bot/conversations.py
@@ -1,0 +1,127 @@
+from telegram.ext import (
+    CommandHandler,
+    MessageHandler,
+    CallbackQueryHandler,
+    ConversationHandler,
+    filters,
+)
+
+from .handlers import (
+    cancel_handler,
+    freeform_handler,
+    sugar_start,
+    sugar_val,
+    photo_handler,
+    doc_handler,
+    photo_sugar_handler,
+    dose_start,
+    dose_method_choice,
+    dose_xe_handler,
+    dose_sugar,
+    dose_carbs,
+    profile_start,
+    profile_icr,
+    profile_cf,
+    profile_target,
+    onb_hello,
+    onb_begin,
+    onb_icr,
+    onb_cf,
+    onb_target,
+    onb_demo_run,
+)
+
+from .handlers import (
+    PROFILE_ICR,
+    PROFILE_CF,
+    PROFILE_TARGET,
+    DOSE_METHOD,
+    DOSE_XE,
+    DOSE_SUGAR,
+    DOSE_CARBS,
+    PHOTO_SUGAR,
+    SUGAR_VAL,
+    ONB_HELLO,
+    ONB_PROFILE_ICR,
+    ONB_PROFILE_CF,
+    ONB_PROFILE_TARGET,
+    ONB_DEMO,
+)
+
+# Onboarding conversation
+onboarding_conv = ConversationHandler(
+    entry_points=[CommandHandler("start", onb_hello)],
+    states={
+        ONB_HELLO: [CallbackQueryHandler(onb_begin, pattern="^onb:start$")],
+        ONB_PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, onb_icr)],
+        ONB_PROFILE_CF: [MessageHandler(filters.TEXT & ~filters.COMMAND, onb_cf)],
+        ONB_PROFILE_TARGET: [MessageHandler(filters.TEXT & ~filters.COMMAND, onb_target)],
+        ONB_DEMO: [CallbackQueryHandler(onb_demo_run, pattern="^onb:demo$")],
+    },
+    fallbacks=[
+        CommandHandler("cancel", cancel_handler),
+        MessageHandler(filters.TEXT & ~filters.COMMAND, freeform_handler),
+    ],
+)
+
+# Sugar conversation
+sugar_conv = ConversationHandler(
+    entry_points=[CommandHandler("sugar", sugar_start)],
+    states={
+        SUGAR_VAL: [MessageHandler(filters.TEXT & ~filters.COMMAND, sugar_val)],
+    },
+    fallbacks=[
+        CommandHandler("cancel", cancel_handler),
+        MessageHandler(filters.TEXT & ~filters.COMMAND, freeform_handler),
+    ],
+)
+
+# Photo processing conversation
+photo_conv = ConversationHandler(
+    entry_points=[
+        MessageHandler(filters.PHOTO, photo_handler),
+        MessageHandler(filters.Document.IMAGE, doc_handler),
+    ],
+    states={
+        PHOTO_SUGAR: [MessageHandler(filters.TEXT & ~filters.COMMAND, photo_sugar_handler)],
+    },
+    fallbacks=[
+        CommandHandler("cancel", cancel_handler),
+        MessageHandler(filters.TEXT & ~filters.COMMAND, freeform_handler),
+    ],
+)
+
+# Dose calculation conversation
+dose_conv = ConversationHandler(
+    entry_points=[
+        CommandHandler("dose", dose_start),
+        MessageHandler(filters.Regex("^💉 Доза инсулина$"), dose_start),
+    ],
+    states={
+        DOSE_METHOD: [MessageHandler(filters.TEXT & ~filters.COMMAND, dose_method_choice)],
+        DOSE_XE: [MessageHandler(filters.TEXT & ~filters.COMMAND, dose_xe_handler)],
+        DOSE_SUGAR: [MessageHandler(filters.TEXT & ~filters.COMMAND, dose_sugar)],
+        DOSE_CARBS: [MessageHandler(filters.TEXT & ~filters.COMMAND, dose_carbs)],
+    },
+    fallbacks=[
+        CommandHandler("cancel", cancel_handler),
+        MessageHandler(filters.TEXT & ~filters.COMMAND, freeform_handler),
+    ],
+)
+
+# Profile editing conversation
+profile_conv = ConversationHandler(
+    entry_points=[
+        CommandHandler("profile", profile_start),
+        MessageHandler(filters.Regex(r"^🔄 Изменить профиль$"), profile_start),
+    ],
+    states={
+        PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_icr)],
+        PROFILE_CF: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_cf)],
+        PROFILE_TARGET: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)],
+    },
+    fallbacks=[
+        CommandHandler("cancel", cancel_handler),
+        MessageHandler(filters.TEXT & ~filters.COMMAND, freeform_handler),
+    ],
+)

--- a/bot/startup.py
+++ b/bot/startup.py
@@ -1,0 +1,27 @@
+import logging
+import os
+from config import OPENAI_PROXY, validate_tokens
+
+
+def setup() -> logging.Logger:
+    """Configure logging and validate tokens."""
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        level=logging.INFO,
+        handlers=[
+            logging.FileHandler("bot.log"),
+            logging.StreamHandler(),
+        ],
+    )
+    logger = logging.getLogger("bot")
+
+    validate_tokens()
+    # os.environ["HTTP_PROXY"] = OPENAI_PROXY
+    # os.environ["HTTPS_PROXY"] = OPENAI_PROXY
+
+    for name in ("httpcore", "httpx", "telegram", "telegram.ext"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+    logging.info("=== Bot started ===")
+    logger.info("Логгер настроен, бот запускается")
+    return logger

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,0 +1,26 @@
+import re
+
+
+def extract_nutrition_info(text: str):
+    """Parse carbs and XE values from Vision text."""
+    carbs = xe = None
+
+    m = re.search(r"углевод[^\d]*:\s*([\d.,]+)\s*г", text, re.IGNORECASE)
+    if m:
+        carbs = float(m.group(1).replace(",", "."))
+
+    m = re.search(r"\bх[еe][^\d]*:\s*([\d.,]+)", text, re.IGNORECASE)
+    if m:
+        xe = float(m.group(1).replace(",", "."))
+
+    if carbs is None:
+        rng = re.search(r"(\d+[.,]?\d*)\s*[–-]\s*(\d+[.,]?\d*)\s*г", text, re.IGNORECASE)
+        if rng:
+            carbs = (float(rng.group(1).replace(",", ".")) + float(rng.group(2).replace(",", "."))) / 2
+
+    if xe is None:
+        rng = re.search(r"(\d+[.,]?\d*)\s*[–-]\s*(\d+[.,]?\d*)\s*(?:ХЕ|XE)", text, re.IGNORECASE)
+        if rng:
+            xe = (float(rng.group(1).replace(",", ".")) + float(rng.group(2).replace(",", "."))) / 2
+
+    return carbs, xe


### PR DESCRIPTION
## Summary
- organize bot code under new `bot` package
- move startup config to `bot.startup`
- move handlers to `bot.handlers`
- create `bot.conversations` for conversation flows
- update `bot.py` to use new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68893a0e951c832a9c3be8df46869c79