### PR TITLE
Add test for cancel_handler menu keyboard

### DIFF
--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,0 +1,25 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import pytest
+
+# Set dummy env vars before importing handlers
+os.environ.setdefault('TELEGRAM_TOKEN', 'x')
+os.environ.setdefault('OPENAI_API_KEY', 'x')
+os.environ.setdefault('OPENAI_ASSISTANT_ID', 'x')
+
+from telegram.ext import ConversationHandler
+from bot.handlers import cancel_handler, menu_keyboard
+
+@pytest.mark.asyncio
+async def test_cancel_handler_returns_menu():
+    message = SimpleNamespace(reply_text=AsyncMock())
+    update = SimpleNamespace(message=message)
+    context = SimpleNamespace()
+
+    result = await cancel_handler(update, context)
+
+    message.reply_text.assert_awaited_with(
+        "❌ Действие отменено.", reply_markup=menu_keyboard
+    )
+    assert result == ConversationHandler.END


### PR DESCRIPTION
## Summary
- add a new test covering `cancel_handler` to ensure it returns `menu_keyboard`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688994c6e588832aac5f51ecff416856