### PR TITLE
Add test requirements and clarify README testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,16 @@
 
 ## Тестирование и линтинг
 
+Перед запуском тестов убедитесь, что установлены все зависимости из
+`requirements.txt` (например, FastAPI используется в модуле `api`).
+
 1. Создайте виртуальное окружение и установите зависимости:
    ```bash
    python -m venv venv
    source venv/bin/activate
    pip install -r requirements.txt
-   pip install pytest
+   # зависимости для тестов, включая pytest и pytest-asyncio
+   pip install -r requirements-test.txt
    ```
 2. Запустите проверки:
    ```bash

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest>=8.4
+pytest-asyncio>=0.23


### PR DESCRIPTION
## Summary
- mention installing FastAPI and other dependencies before running tests
- load test dependencies from new `requirements-test.txt`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889972afd40832aa3449ab3c549d042