### PR TITLE
Ensure send_message has content or image

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -31,7 +31,11 @@ def send_message(thread_id: str, content: str | None = None, image_path: str | N
     """
     Отправляет текст или (изображение + текст) в thread
     и запускает run с ассистентом.  Возвращает объект run.
+    Требует хотя бы один из параметров: content или image_path.
     """
+    if content is None and image_path is None:
+        logging.warning("[OpenAI] send_message called without content or image_path")
+        raise ValueError("Either content or image_path must be provided")
     # 1. Подготовка контента
     if image_path:
         try:


### PR DESCRIPTION
## Summary
- validate that `send_message` receives either text or an image
- warn and raise `ValueError` when both `content` and `image_path` are missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e0826a550832ab9d9734df02aa6db