### PR TITLE
Avoid blocking OpenAI calls

### DIFF
--- a/gpt_command_parser.py
+++ b/gpt_command_parser.py
@@ -1,4 +1,4 @@
-import os, json, logging
+import os, json, logging, asyncio
 from openai import OpenAI
 from config import OPENAI_API_KEY, OPENAI_PROXY, validate_tokens
 
@@ -47,8 +47,16 @@ SYSTEM_PROMPT = (
 
 
 async def parse_command(text: str) -> dict | None:
+    """Parse user's free-form text into a structured command.
+
+    The OpenAI client call is executed in a background thread to avoid
+    blocking the event loop.
+    """
     try:
-        response = client.chat.completions.create(
+        # Run the blocking client call in a separate thread so the event loop
+        # remains responsive.
+        response = await asyncio.to_thread(
+            client.chat.completions.create,
             model="gpt-4o-mini",
             messages=[
                 {"role": "system", "content": SYSTEM_PROMPT},


### PR DESCRIPTION
## Summary
- Run OpenAI chat completions in a background thread via `asyncio.to_thread` to keep the event loop responsive
- Add asyncio import and document the rationale

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e0b9b9314832a886756c9ceaf7c59