### PR TITLE
Handle OpenAI report generation asynchronously

### DIFF
--- a/report.py
+++ b/report.py
@@ -1,4 +1,6 @@
+import asyncio
 import io
+import logging
 import re
 from datetime import datetime
 import matplotlib.pyplot as plt
@@ -192,16 +194,21 @@ async def send_report(update, context, date_from, period_label, query=None):
         + "Сделай анализ, дай советы по контролю сахара и питанию, укажи возможные проблемы."
     )
 
-    gpt_response = client.chat.completions.create(
-        model="gpt-4o-mini",
-        messages=[
-            {"role": "system", "content": "Ты — медицинский ассистент для диабетиков."},
-            {"role": "user", "content": gpt_prompt},
-        ],
-        temperature=0.2,
-        max_tokens=600,
-    )
-    gpt_text = gpt_response.choices[0].message.content.strip()
+    try:
+        gpt_response = await asyncio.to_thread(
+            client.chat.completions.create,
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": "Ты — медицинский ассистент для диабетиков."},
+                {"role": "user", "content": gpt_prompt},
+            ],
+            temperature=0.2,
+            max_tokens=600,
+        )
+        gpt_text = gpt_response.choices[0].message.content.strip()
+    except Exception as e:
+        logging.error(f"Report generation failed: {e}")
+        gpt_text = "Не удалось получить рекомендации."
 
     report_msg = (
         f"<b>📈 Отчёт за {period_label}</b>\n\n"


### PR DESCRIPTION
## Summary
- Avoid blocking event loop by running OpenAI chat completion in a background thread.
- Add asyncio and logging imports and gracefully handle errors from thread.

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e0c5718c4832a8cc3e5adf5b9ae80