### PR TITLE
Strip whitespace before protocol lookup

### DIFF
--- a/services.py
+++ b/services.py
@@ -4,6 +4,6 @@ PROTOCOLS = {
 }
 
 def find_protocol_by_diagnosis(diagnosis: str) -> str | None:
-    diagnosis = diagnosis.lower()
+    diagnosis = diagnosis.strip().lower()
     return PROTOCOLS.get(diagnosis)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -10,3 +10,7 @@ def test_find_protocol_not_found():
     assert find_protocol_by_diagnosis("Неизвестный диагноз") is None
 
 
+def test_find_protocol_trims_whitespace():
+    assert find_protocol_by_diagnosis("  Диабет 2 типа  ") == "standard protocol"
+
+


### PR DESCRIPTION
## Summary
- Trim leading/trailing spaces in diagnosis before protocol lookup.
- Add unit test verifying lookup with surrounding whitespace.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e0e29c890832ab830585ef07eb915