### PR TITLE
Validate positive ratios before bolus calculation

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1,13 +1,33 @@
 # functions.py
 from dataclasses import dataclass
 
+
 @dataclass
 class PatientProfile:
     icr: float
     cf: float
     target_bg: float
 
+
 def calc_bolus(carbs_g: float, current_bg: float, profile: PatientProfile) -> float:
+    """Calculate insulin bolus for a meal.
+
+    Args:
+        carbs_g: Amount of carbohydrates in grams.
+        current_bg: Current blood glucose level.
+        profile: Patient parameters with insulin-to-carb ratio (icr),
+            correction factor (cf) and target blood glucose.
+
+    Returns:
+        Recommended bolus rounded to one decimal place.
+
+    Raises:
+        ValueError: If ``profile.icr`` or ``profile.cf`` are not positive.
+    """
+
+    if profile.icr <= 0 or profile.cf <= 0:
+        raise ValueError("icr and cf must be positive values")
+
     meal = carbs_g / profile.icr
     correction = max(0, (current_bg - profile.target_bg) / profile.cf)
     return round(meal + correction, 1)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -23,3 +23,15 @@ def test_calc_bolus():
     assert calc_bolus(30, 6, profile) == 3.0
     # сахар ниже целевого — коррекция не добавляется
     assert calc_bolus(24, 4, profile) == 2.4
+
+
+@pytest.mark.parametrize("icr, cf", [
+    (0, 2),
+    (-1, 2),
+    (10, 0),
+    (10, -1),
+])
+def test_calc_bolus_invalid_profile(icr, cf):
+    profile = PatientProfile(icr=icr, cf=cf, target_bg=6)
+    with pytest.raises(ValueError):
+        calc_bolus(50, 10, profile)


### PR DESCRIPTION
## Summary
- ensure `calc_bolus` checks that `icr` and `cf` are positive and raise `ValueError` otherwise
- document new validation rules in `calc_bolus`
- test profile validation for invalid ratios

## Testing
- `pytest tests/test_parsing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e0f1026dc832a80a17cc1d2ce55ed