### PR TITLE
Alias datetime time for freeform handler

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -2,7 +2,7 @@ import logging
 import re
 import asyncio
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timezone, time as dtime
 
 logger = logging.getLogger("bot")
 


### PR DESCRIPTION
## Summary
- Import `time` from `datetime` as `dtime`
- Use `dtime` in `datetime.combine` when parsing freeform input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e14da88b8832a9a07eb385d568bb0