### PR TITLE
Import timedelta for report periods

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -2,7 +2,7 @@ import logging
 import re
 import asyncio
 import time
-from datetime import datetime, timezone, time as dtime
+from datetime import datetime, timezone, timedelta, time as dtime
 
 logger = logging.getLogger("bot")
 


### PR DESCRIPTION
## Summary
- import `timedelta` in bot handlers for easier date arithmetic
- ensure report periods subtract days with `timedelta`

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_688e15bb7880832ab64f94d60c404935