### PR TITLE
Remove token validation from database module

### DIFF
--- a/db.py
+++ b/db.py
@@ -8,9 +8,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import declarative_base, sessionmaker, relationship
 
-from config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD, validate_tokens
-
-validate_tokens()
+from config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
 
 
 # ────────────────── подключение к Postgres ──────────────────


### PR DESCRIPTION
## Summary
- drop unnecessary `validate_tokens()` call from `db.py` to restrict credential checks to relevant components

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e1753b2e0832ab1245370ae6a2396