### PR TITLE
Fix cancel entry keyboard

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -340,7 +340,8 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
     if data == "cancel_entry":
         context.user_data.pop('pending_entry', None)
-        await query.edit_message_text("❌ Запись отменена.", reply_markup=menu_keyboard)
+        await query.edit_message_text("❌ Запись отменена.", reply_markup=None)
+        await query.message.reply_text("Пожалуйста, выберите действие:", reply_markup=menu_keyboard)
         return
 
     # --- Старый код: обработка истории ---


### PR DESCRIPTION
## Summary
- ensure cancel entry query displays menu correctly by sending reply keyboard separately

## Testing
- `pytest`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_688e1ef07758832aba5cbdb17b35fcfb