### PR TITLE
[utils] Strip heading markers only at line start

### DIFF
--- a/diabetes/utils.py
+++ b/diabetes/utils.py
@@ -10,7 +10,7 @@ def clean_markdown(text):
     Удаляет простую Markdown-разметку: **жирный**, # заголовки, * списки, 1. списки и т.д.
     """
     text = re.sub(r'\*\*([^*]+)\*\*', r'\1', text)  # **жирный**
-    text = re.sub(r'#+\s*', '', text)                  # ### Заголовки
+    text = re.sub(r'^#+\s*', '', text, flags=re.MULTILINE)  # ### Заголовки
     text = re.sub(r'^\s*\d+\.\s*', '', text, flags=re.MULTILINE)  # 1. списки
     text = re.sub(r'^\s*\*\s*', '', text, flags=re.MULTILINE)      # * списки
     text = re.sub(r'`([^`]+)`', r'\1', text)           # `код`

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,10 +3,11 @@
 from diabetes.utils import clean_markdown, split_text_by_width
 
 def test_clean_markdown():
-    text = "**Жирный** # Заголовок\n* элемент\n1. Первый"
+    text = "**Жирный**\n# Заголовок\n* элемент\n1. Первый"
     cleaned = clean_markdown(text)
     assert "Жирный" in cleaned
     assert "Заголовок" in cleaned
+    assert "#" not in cleaned
     assert "*" not in cleaned
     assert "1." not in cleaned
 


### PR DESCRIPTION
## Summary
- Restrict markdown heading stripping to the start of lines in `clean_markdown`
- Update utility tests to cover start-of-line heading removal

## Testing
- `flake8 diabetes/ && echo 'flake8: OK'`
- `pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_688e2b3a2188832a9f5c442186d36ac6