### PR TITLE
[functions] validate profile ratios before bolus calculation

### DIFF
--- a/diabetes/functions.py
+++ b/diabetes/functions.py
@@ -15,6 +15,10 @@ def calc_bolus(carbs_g: float, current_bg: float, profile: PatientProfile) -> fl
     """
     Расчёт болюса (дозы инсулина) по углеводам и сахару.
     """
+    if profile.icr <= 0:
+        raise ValueError("Profile icr must be greater than 0")
+    if profile.cf <= 0:
+        raise ValueError("Profile cf must be greater than 0")
     meal = carbs_g / profile.icr
     correction = max(0, (current_bg - profile.target_bg) / profile.cf)
     return round(meal + correction, 1)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,5 +1,7 @@
 # test_functions.py
 
+import pytest
+
 from diabetes.functions import calc_bolus, PatientProfile, extract_nutrition_info
 
 def test_calc_bolus_basic():
@@ -13,6 +15,18 @@ def test_calc_bolus_no_correction():
     result = calc_bolus(carbs_g=30, current_bg=5, profile=profile)
     # meal=3, correction=max(0, (5-6)/2)=0, total=3.0
     assert result == 3.0
+
+
+def test_calc_bolus_invalid_icr():
+    profile = PatientProfile(icr=0, cf=2, target_bg=6)
+    with pytest.raises(ValueError, match="icr"):
+        calc_bolus(carbs_g=30, current_bg=5, profile=profile)
+
+
+def test_calc_bolus_invalid_cf():
+    profile = PatientProfile(icr=10, cf=-1, target_bg=6)
+    with pytest.raises(ValueError, match="cf"):
+        calc_bolus(carbs_g=30, current_bg=5, profile=profile)
 
 def test_extract_nutrition_info_simple():
     text = "углеводы: 45 г, ХЕ: 3.5"


### PR DESCRIPTION
## Summary
- ensure calc_bolus raises if insulin-to-carb or correction factors are non-positive
- test invalid ICR and CF cases

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_688e2e5d6980832abdb56baa3ad4999f