### PR TITLE
[handlers] Correct profile units and add test

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -456,8 +456,8 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if len(args) != 3:
         await update.message.reply_text(
             "❗ Формат команды:\n"
-            "/profile <ИКХ> <КЧ> <целевой>\n"
-            "Пример: /profile 2 10 6",
+            "/profile <ИКХ г/ед.> <КЧ ммоль/л> <целевой>\n"
+            "Пример: /profile 10 2 6",
             parse_mode="Markdown"
         )
         return
@@ -473,8 +473,8 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if icr > 8 or cf < 3:
             warning_msg = (
                 "\n⚠️ Проверьте, пожалуйста: возможно, вы перепутали местами ИКХ и КЧ.\n"
-                f"• Вы ввели ИКХ = {icr} ммоль/л (высоковато)\n"
-                f"• КЧ = {cf} г/ед. (низковато)\n\n"
+                f"• Вы ввели ИКХ = {icr} г/ед. (высоковато)\n"
+                f"• КЧ = {cf} ммоль/л (низковато)\n\n"
                 "Если вы хотели ввести наоборот, отправьте:\n"
                 f"/profile {cf} {icr} {target}\n"
             )
@@ -494,8 +494,8 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         await update.message.reply_text(
             f"✅ Профиль обновлён:\n"
-            f"• ИКХ: {icr} ммоль/л\n"
-            f"• КЧ: {cf} г/ед.\n"
+            f"• ИКХ: {icr} г/ед.\n"
+            f"• КЧ: {cf} ммоль/л\n"
             f"• Целевой сахар: {target} ммоль/л"
             + warning_msg,
             parse_mode="Markdown"
@@ -503,7 +503,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     except ValueError:
         await update.message.reply_text(
-            "❗ Пожалуйста, введите корректные числа. Пример:\n/profile 2 10 6",
+            "❗ Пожалуйста, введите корректные числа. Пример:\n/profile 10 2 6",
             parse_mode="Markdown"
         )
 
@@ -518,16 +518,16 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(
             "Ваш профиль пока не настроен.\n\n"
             "Чтобы настроить профиль, введите команду:\n"
-            "/profile <ИКХ> <КЧ> <целевой>\n"
-            "Пример: /profile 2 10 6",
+            "/profile <ИКХ г/ед.> <КЧ ммоль/л> <целевой>\n"
+            "Пример: /profile 10 2 6",
             parse_mode="Markdown"
         )
         return
 
     msg = (
         f"📄 Ваш профиль:\n"
-        f"• ИКХ: {profile.cf} ммоль/л\n"
-        f"• КЧ: {profile.icr} г/ед.\n"
+        f"• ИКХ: {profile.icr} г/ед.\n"
+        f"• КЧ: {profile.cf} ммоль/л\n"
         f"• Целевой сахар: {profile.target_bg} ммоль/л"
     )
     await update.message.reply_text(msg)

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -1,0 +1,47 @@
+import pytest
+from types import SimpleNamespace
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from diabetes.db import Base, User
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+@pytest.mark.asyncio
+async def test_profile_command_and_view(monkeypatch):
+    import os
+    os.environ["OPENAI_API_KEY"] = "test"
+    import diabetes.handlers as handlers
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+
+    monkeypatch.setattr(handlers, "SessionLocal", TestSession)
+
+    with TestSession() as session:
+        session.add(User(telegram_id=123, thread_id="t"))
+        session.commit()
+
+    message = DummyMessage()
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123))
+    context = SimpleNamespace(args=["8", "3", "6"], user_data={})
+
+    await handlers.profile_command(update, context)
+    assert "ИКХ: 8.0 г/ед." in message.texts[0]
+    assert "КЧ: 3.0 ммоль/л" in message.texts[0]
+
+    message2 = DummyMessage()
+    update2 = SimpleNamespace(message=message2, effective_user=SimpleNamespace(id=123))
+    context2 = SimpleNamespace(user_data={})
+
+    await handlers.profile_view(update2, context2)
+    assert "ИКХ: 8.0 г/ед." in message2.texts[0]
+    assert "КЧ: 3.0 ммоль/л" in message2.texts[0]


### PR DESCRIPTION
## Summary
- show ICR (ИКХ) in g/ed and CF (КЧ) in mmol/L in profile commands
- clarify unit labels in profile setup prompts
- test profile output formatting

## Testing
- `flake8 diabetes`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e31f7a42c832aa80b4bb810417288