### PR TITLE
[handlers] Remove local gpt_client import

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -755,7 +755,6 @@ async def dose_xe_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo: bool = False):
-    from diabetes.gpt_client import client, send_message, create_thread
 
     message = update.message or update.callback_query.message
     user_id = update.effective_user.id


### PR DESCRIPTION
## Summary
- remove redundant gpt_client import inside photo_handler
- use top-level create_thread, send_message, and client

## Testing
- `pytest tests/`
- `flake8 diabetes/`


------
https://chatgpt.com/codex/tasks/task_e_688e3672dd90832abcc08bc87a95c5c9