### PR TITLE
[gpt_command_parser] Handle OpenAI timeouts without blocking

### DIFF
--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -1,0 +1,32 @@
+import asyncio
+import os
+import time
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+from diabetes import gpt_command_parser
+
+
+@pytest.mark.asyncio
+async def test_parse_command_timeout_non_blocking(monkeypatch):
+    def slow_create(*args, **kwargs):
+        time.sleep(1)
+        class FakeResponse:
+            choices = [type("Choice", (), {"message": type("Msg", (), {"content": "{}"})()})]
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        gpt_command_parser.client.chat.completions,
+        "create",
+        slow_create,
+    )
+
+    start = time.perf_counter()
+    result, _ = await asyncio.gather(
+        gpt_command_parser.parse_command("test", timeout=0.1),
+        asyncio.sleep(0.1),
+    )
+    elapsed = time.perf_counter() - start
+
+    assert result is None
+    assert elapsed < 0.5


### PR DESCRIPTION
## Summary
- run OpenAI calls in a background thread and enforce a timeout in `parse_command`
- add a test ensuring slow OpenAI responses time out and don't block other tasks

## Testing
- `flake8 diabetes/`
- `pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_688e37f271ec832abf04002f6f8d5f10