### PR TITLE
Use asyncio.to_thread for send_message calls

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -739,10 +739,11 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
     try:
         # 2. Запуск Vision run
         thread_id = context.user_data.get("thread_id") or create_thread()
-        run = send_message(
+        run = await asyncio.to_thread(
+            send_message,
             thread_id=thread_id,
             content="Определи количество углеводов и ХЕ на фото блюда. Используй формат из системных инструкций ассистента.",
-            image_path=file_path
+            image_path=file_path,
         )
         await message.reply_text("🔍 Анализирую фото (это займёт 5‑10 с)…")
 
@@ -953,7 +954,11 @@ async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
 
     # 1) отправляем сообщение (или изображение) в GPT
-    run = send_message(user.thread_id, content=update.message.text)
+    run = await asyncio.to_thread(
+        send_message,
+        user.thread_id,
+        content=update.message.text,
+    )
     await update.message.reply_text("⏳ Жду ответ от GPT...")
 
     # 2) ждём, пока Assistant закончит


### PR DESCRIPTION
## Summary
- run blocking OpenAI `send_message` in a worker thread during photo analysis
- offload text chat `send_message` call to a thread to keep event loop responsive

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e3ffaed30832a966bf246ca3482ce