### PR TITLE
Log add_entry failures

### DIFF
--- a/db_access.py
+++ b/db_access.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from typing import List
 from db import SessionLocal, Profile, Entry
@@ -27,6 +28,7 @@ def add_entry(entry_data: dict) -> None:
         try:
             session.commit()
         except Exception:
+            logging.exception("Failed to add entry")
             session.rollback()
             raise
 


### PR DESCRIPTION
## Summary
- log database entry commit failures with logging.exception before rollback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e40f3032c832a9f4612b05b5262f8