### PR TITLE
Log PDF graph rendering failures

### DIFF
--- a/report.py
+++ b/report.py
@@ -123,11 +123,17 @@ def generate_pdf_report(summary_lines, errors, day_lines, gpt_text, buf_graph):
     if buf_graph:
         y -= 10 * mm
         try:
-            c.drawImage(ImageReader(buf_graph), 20 * mm, y - 60 * mm,
-                        width=170 * mm, height=50 * mm, preserveAspectRatio=True)
+            c.drawImage(
+                ImageReader(buf_graph),
+                20 * mm,
+                y - 60 * mm,
+                width=170 * mm,
+                height=50 * mm,
+                preserveAspectRatio=True,
+            )
             y -= 60 * mm
         except Exception:
-            pass
+            logging.exception("Failed to render graph in PDF report")
     c.save()
     pdf_buf.seek(0)
     return pdf_buf


### PR DESCRIPTION
## Summary
- log errors when rendering the graph to the PDF report instead of swallowing exceptions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e42032700832aaf043bf38aa775d8