### PR TITLE
Validate non-negative inputs in bolus calculation

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -22,11 +22,15 @@ def calc_bolus(carbs_g: float, current_bg: float, profile: PatientProfile) -> fl
         Recommended bolus rounded to one decimal place.
 
     Raises:
-        ValueError: If ``profile.icr`` or ``profile.cf`` are not positive.
+        ValueError: If ``profile.icr`` or ``profile.cf`` are not positive,
+            or ``carbs_g`` or ``current_bg`` are negative.
     """
 
     if profile.icr <= 0 or profile.cf <= 0:
         raise ValueError("icr and cf must be positive values")
+
+    if carbs_g < 0 or current_bg < 0:
+        raise ValueError("carbs_g and current_bg must be non-negative values")
 
     meal = carbs_g / profile.icr
     correction = max(0, (current_bg - profile.target_bg) / profile.cf)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -35,3 +35,14 @@ def test_calc_bolus_invalid_profile(icr, cf):
     profile = PatientProfile(icr=icr, cf=cf, target_bg=6)
     with pytest.raises(ValueError):
         calc_bolus(50, 10, profile)
+
+
+@pytest.mark.parametrize("carbs_g, current_bg", [
+    (-1, 5),
+    (10, -1),
+    (-5, -1),
+])
+def test_calc_bolus_negative_inputs(carbs_g, current_bg):
+    profile = PatientProfile(icr=10, cf=2, target_bg=6)
+    with pytest.raises(ValueError):
+        calc_bolus(carbs_g, current_bg, profile)


### PR DESCRIPTION
## Summary
- ensure `calc_bolus` raises `ValueError` when `carbs_g` or `current_bg` are negative
- add tests covering negative `carbs_g` and `current_bg` values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e4338b974832ab144c95638a450e6