### PR TITLE
Handle empty choices in GPT command parser

### DIFF
--- a/gpt_command_parser.py
+++ b/gpt_command_parser.py
@@ -65,7 +65,11 @@ async def parse_command(text: str) -> dict | None:
             temperature=0,
             max_tokens=256
         )
-        content = response.choices[0].message.content.strip()
+        choices = getattr(response, "choices", [])
+        if not choices:
+            logging.error("OpenAI completion returned no choices")
+            return None
+        content = choices[0].message.content.strip()
         logging.info(f"GPT parse response: {content}")
         return json.loads(content)
     except Exception as e:


### PR DESCRIPTION
## Summary
- avoid indexing when the OpenAI response contains no choices
- log and return `None` when the completion response is empty

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e443fc608832a8cba5fad19cf4cdb