### PR TITLE
[functions] Validate non-negative inputs

### DIFF
--- a/diabetes/functions.py
+++ b/diabetes/functions.py
@@ -19,6 +19,10 @@ def calc_bolus(carbs_g: float, current_bg: float, profile: PatientProfile) -> fl
         raise ValueError("Profile icr must be greater than 0")
     if profile.cf <= 0:
         raise ValueError("Profile cf must be greater than 0")
+    if carbs_g < 0:
+        raise ValueError("carbs_g must be non-negative")
+    if current_bg < 0:
+        raise ValueError("current_bg must be non-negative")
     meal = carbs_g / profile.icr
     correction = max(0, (current_bg - profile.target_bg) / profile.cf)
     return round(meal + correction, 1)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -28,6 +28,18 @@ def test_calc_bolus_invalid_cf():
     with pytest.raises(ValueError, match="cf"):
         calc_bolus(carbs_g=30, current_bg=5, profile=profile)
 
+
+def test_calc_bolus_negative_carbs():
+    profile = PatientProfile(icr=10, cf=2, target_bg=6)
+    with pytest.raises(ValueError, match="carbs_g"):
+        calc_bolus(carbs_g=-5, current_bg=5, profile=profile)
+
+
+def test_calc_bolus_negative_current_bg():
+    profile = PatientProfile(icr=10, cf=2, target_bg=6)
+    with pytest.raises(ValueError, match="current_bg"):
+        calc_bolus(carbs_g=30, current_bg=-1, profile=profile)
+
 def test_extract_nutrition_info_simple():
     text = "углеводы: 45 г, ХЕ: 3.5"
     carbs, xe = extract_nutrition_info(text)


### PR DESCRIPTION
## Summary
- ensure `calc_bolus` rejects negative carb or blood glucose values
- test negative carbs and BG in `calc_bolus`

## Testing
- `pytest tests/ -q`
- `flake8 diabetes/`


------
https://chatgpt.com/codex/tasks/task_e_688e4669d998832a9dd5fdebfbe09244