### PR TITLE
[handlers] Improve document image handling

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -769,7 +769,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
     if not file_path:
         try:
             photo = update.message.photo[-1]
-        except (AttributeError, IndexError):
+        except (AttributeError, IndexError, TypeError):
             await message.reply_text("❗ Файл не распознан как изображение.")
             context.user_data.pop(WAITING_GPT_FLAG, None)
             return ConversationHandler.END
@@ -865,8 +865,8 @@ async def doc_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     # кладём путь и «псевдо‑фото» в update, чтобы дальше всё работало
     context.user_data["__file_path"] = path
-    # чтобы код, который где‑то проверяет .photo, не упал
-             # пустой список‑заглушка
+    update.message.photo = []  # чтобы код, который где‑то проверяет .photo, не упал
+    # пустой список‑заглушка
 
     # переходим в обычный обработчик фото
     return await photo_handler(update, context)

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -1,0 +1,64 @@
+import pytest
+from types import SimpleNamespace
+
+import diabetes.handlers as handlers
+
+
+class DummyMessage:
+    def __init__(self, photo=None):
+        self.photo = photo
+        self.texts = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+@pytest.mark.asyncio
+async def test_doc_handler_calls_photo_handler(monkeypatch):
+    called = SimpleNamespace(flag=False)
+
+    async def fake_photo_handler(update, context):
+        called.flag = True
+        return "OK"
+
+    class DummyFile:
+        async def download_to_drive(self, path):
+            self.path = path
+
+    async def fake_get_file(file_id):
+        return DummyFile()
+
+    dummy_bot = SimpleNamespace(get_file=fake_get_file)
+
+    document = SimpleNamespace(
+        file_name="img.png",
+        file_unique_id="uid",
+        file_id="fid",
+        mime_type="image/png",
+    )
+    message = SimpleNamespace(document=document, photo=None)
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(bot=dummy_bot, user_data={})
+
+    monkeypatch.setattr(handlers, "photo_handler", fake_photo_handler)
+    monkeypatch.setattr(handlers.os, "makedirs", lambda *args, **kwargs: None)
+
+    result = await handlers.doc_handler(update, context)
+
+    assert result == "OK"
+    assert called.flag
+    assert context.user_data["__file_path"] == "photos/1_uid.png"
+    assert update.message.photo == []
+
+
+@pytest.mark.asyncio
+async def test_photo_handler_handles_typeerror():
+    message = DummyMessage(photo=None)
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+
+    result = await handlers.photo_handler(update, context)
+
+    assert message.texts == ["❗ Файл не распознан как изображение."]
+    assert result == handlers.ConversationHandler.END
+    assert handlers.WAITING_GPT_FLAG not in context.user_data


### PR DESCRIPTION
## Summary
- Prevent crashes when document images lack `photo` field by providing an empty list
- Handle `TypeError` when extracting photo data
- Add tests for document-image flow and photo handler edge cases

## Testing
- `pytest`
- `flake8 diabetes`

------
https://chatgpt.com/codex/tasks/task_e_688e49bec26c832a91cc677f8f6e5eaf