### PR TITLE
[gpt_client] Ensure message has content

### DIFF
--- a/diabetes/gpt_client.py
+++ b/diabetes/gpt_client.py
@@ -26,6 +26,8 @@ def send_message(thread_id: str, content: str | None = None, image_path: str | N
     Отправляет текст или (изображение + текст) в thread
     и запускает run с ассистентом.  Возвращает объект run.
     """
+    if content is None and image_path is None:
+        raise ValueError("Either 'content' or 'image_path' must be provided")
     # 1. Подготовка контента
     if image_path:
         try:


### PR DESCRIPTION
## Summary
- validate that `send_message` receives either text or an image before sending

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_688e5a4874c4832aa1fd1b88261da86c