### PR TITLE
[logging] Move logging configuration to entry point

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,12 +7,20 @@ from telegram.ext import ApplicationBuilder
 import logging
 import sys
 
-logging.basicConfig(level=logging.INFO)
-logging.info("=== Bot started ===")
+logger = logging.getLogger(__name__)
+
 
 def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    logger.info("=== Bot started ===")
+
     if not TELEGRAM_TOKEN:
-        logging.error("TELEGRAM_TOKEN is not set. Please provide the environment variable.")
+        logger.error(
+            "TELEGRAM_TOKEN is not set. Please provide the environment variable."
+        )
         sys.exit(1)
 
     init_db()

--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -28,7 +28,6 @@ from diabetes.gpt_command_parser import parse_command
 from diabetes.ui import menu_keyboard, dose_keyboard, confirm_keyboard
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 
 


### PR DESCRIPTION
## Summary
- configure logging in bot.py with format and INFO level
- remove logging setup from handlers module

## Testing
- `flake8 diabetes/`
- `pytest tests/` *(fails: async def functions are not natively supported in this event loop)*

------
https://chatgpt.com/codex/tasks/task_e_688e5be992f4832a89509094d6c3d1d3