### PR TITLE
[ui] Align menu buttons with handlers

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -1256,6 +1256,7 @@ onboarding_conv = ConversationHandler(
 sugar_conv = ConversationHandler(
     entry_points=[
         CommandHandler("sugar", sugar_start),
+        MessageHandler(filters.Regex("^❓ Мой сахар$"), sugar_start),
     ],
     states={
         SUGAR_VAL: [MessageHandler(filters.TEXT & ~filters.COMMAND, sugar_val)],
@@ -1325,7 +1326,6 @@ def register_handlers(app):
     app.add_handler(CommandHandler("profile", profile_command))
     app.add_handler(MessageHandler(filters.Regex("^📄 Мой профиль$"), profile_view))
     app.add_handler(MessageHandler(filters.Regex(r"^📊 История$"), history_handler))
-    app.add_handler(MessageHandler(filters.Regex(r"^❓ Мой сахар$"), sugar_start))
     app.add_handler(sugar_conv)
     app.add_handler(photo_conv)
     app.add_handler(profile_conv)

--- a/diabetes/ui.py
+++ b/diabetes/ui.py
@@ -20,9 +20,9 @@ __all__ = ("menu_keyboard", "dose_keyboard", "confirm_keyboard")
 
 menu_keyboard = ReplyKeyboardMarkup(
     keyboard=[
-        [KeyboardButton("📷 Фото"), KeyboardButton("🩸 Сахар")],
-        [KeyboardButton("💉 Доза"), KeyboardButton("📜 История")],
-        [KeyboardButton("📊 Отчёт")],
+        [KeyboardButton("📷 Фото еды"), KeyboardButton("❓ Мой сахар")],
+        [KeyboardButton("💉 Доза инсулина"), KeyboardButton("📊 История")],
+        [KeyboardButton("📈 Отчёт"), KeyboardButton("📄 Мой профиль")],
     ],
     resize_keyboard=True,
     one_time_keyboard=False,


### PR DESCRIPTION
## Summary
- sync main menu labels with button handlers and add missing "My profile" option
- hook "My sugar" button into conversation flow and update handler registration

## Testing
- `flake8 diabetes/`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_688e607c5684832a81ee70d9c986f751