### PR TITLE
[gpt_client] Validate OpenAI credentials before client init

### DIFF
--- a/diabetes/gpt_client.py
+++ b/diabetes/gpt_client.py
@@ -10,6 +10,15 @@ if OPENAI_PROXY:
     os.environ["HTTP_PROXY"] = OPENAI_PROXY
     os.environ["HTTPS_PROXY"] = OPENAI_PROXY
 
+if not OPENAI_API_KEY:
+    message = "OPENAI_API_KEY is not set"
+    logging.error("[OpenAI] %s", message)
+    raise RuntimeError(message)
+if not OPENAI_ASSISTANT_ID:
+    message = "OPENAI_ASSISTANT_ID is not set"
+    logging.error("[OpenAI] %s", message)
+    raise RuntimeError(message)
+
 client = openai.OpenAI(api_key=OPENAI_API_KEY)
 
 logging.info("[OpenAI] Using assistant: %s", OPENAI_ASSISTANT_ID)


### PR DESCRIPTION
## Summary
- ensure OPENAI_API_KEY and OPENAI_ASSISTANT_ID are set before creating the OpenAI client

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_688e627a92a0832a92565d7fb3683468