### PR TITLE
[config] Ensure DB port is integer

### DIFF
--- a/diabetes/config.py
+++ b/diabetes/config.py
@@ -10,7 +10,7 @@ OPENAI_ASSISTANT_ID = os.getenv('OPENAI_ASSISTANT_ID')
 OPENAI_PROXY = os.getenv('OPENAI_PROXY')
 
 DB_HOST = os.getenv('DB_HOST', 'localhost')
-DB_PORT = os.getenv('DB_PORT', '5432')
+DB_PORT = int(os.getenv("DB_PORT", 5432))
 DB_NAME = os.getenv('DB_NAME', 'diabetes_bot')
 DB_USER = os.getenv('DB_USER', 'diabetes_user')
 DB_PASSWORD = os.getenv('DB_PASSWORD', '')

--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -17,7 +17,7 @@ DATABASE_URL = URL.create(
     username=DB_USER,
     password=DB_PASSWORD,
     host=DB_HOST,
-    port=DB_PORT,
+    port=int(DB_PORT),
     database=DB_NAME,
 )
 


### PR DESCRIPTION
## Summary
- cast DB_PORT to int when loading from environment
- pass integer port to SQLAlchemy URL creation

## Testing
- `flake8 diabetes/`
- `pytest tests/` *(fails: OPENAI_ASSISTANT_ID is not set; No module named 'PyPDF2')*

------
https://chatgpt.com/codex/tasks/task_e_688e6516fd8c832aa6b873f51fd468b5