### PR TITLE
[gpt] ensure OPENAI_API_KEY for command parser

### DIFF
--- a/diabetes/gpt_command_parser.py
+++ b/diabetes/gpt_command_parser.py
@@ -10,6 +10,11 @@ if OPENAI_PROXY:
     os.environ["HTTP_PROXY"] = OPENAI_PROXY
     os.environ["HTTPS_PROXY"] = OPENAI_PROXY
 
+if not OPENAI_API_KEY:
+    message = "OPENAI_API_KEY is not set"
+    logging.error("[OpenAI] %s", message)
+    raise RuntimeError(message)
+
 # 2️⃣ Создаём обычный клиент OpenAI — без extra‑аргументов,
 #    он возьмёт прокси из env автоматически.
 client = OpenAI(api_key=OPENAI_API_KEY)


### PR DESCRIPTION
## Summary
- validate `OPENAI_API_KEY` before creating OpenAI client in `gpt_command_parser`

## Testing
- `flake8 diabetes`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_688e66212818832abca4533b4035d2af