### PR TITLE
[handlers] Make event_dt timezone-aware

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -149,19 +149,27 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     # ── определяем event_time ─────────────────────────────────
     if entry_date:
         try:
-            event_dt = datetime.datetime.fromisoformat(entry_date).replace(tzinfo=datetime.timezone.utc)
+            event_dt = datetime.datetime.fromisoformat(entry_date)
+            if event_dt.tzinfo is None:
+                event_dt = event_dt.replace(tzinfo=datetime.timezone.utc)
+            else:
+                event_dt = event_dt.astimezone(datetime.timezone.utc)
         except ValueError:
             event_dt = datetime.datetime.now(datetime.timezone.utc)
     elif time_str:
         try:
             hh, mm = map(int, time_str.split(":"))
-            today = datetime.datetime.now().date()
-            event_dt = datetime.datetime.combine(today, datetime.time(hh, mm))
+            today = datetime.datetime.now(datetime.timezone.utc).date()
+            event_dt = datetime.datetime.combine(
+                today,
+                datetime.time(hh, mm),
+                tzinfo=datetime.timezone.utc,
+            )
         except (ValueError, TypeError):
             await update.message.reply_text(
                 "⏰ Неверный формат времени. Использую текущее время."
             )
-            event_dt = datetime.datetime.now()
+            event_dt = datetime.datetime.now(datetime.timezone.utc)
     else:
         event_dt = datetime.datetime.now(datetime.timezone.utc)
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -18,8 +18,20 @@ class DummyEntry:
 
 def test_make_sugar_plot():
     entries = [
-        DummyEntry(datetime.datetime(2025, 7, 1, 9), 7.0, 40, 3.3, 6),
-        DummyEntry(datetime.datetime(2025, 7, 1, 14), 9.0, 50, 4.1, 8),
+        DummyEntry(
+            datetime.datetime(2025, 7, 1, 9, tzinfo=datetime.timezone.utc),
+            7.0,
+            40,
+            3.3,
+            6,
+        ),
+        DummyEntry(
+            datetime.datetime(2025, 7, 1, 14, tzinfo=datetime.timezone.utc),
+            9.0,
+            50,
+            4.1,
+            8,
+        ),
     ]
     buf = make_sugar_plot(entries, "тестовый период")
     assert hasattr(buf, 'read')
@@ -28,7 +40,13 @@ def test_make_sugar_plot():
 
 def test_generate_pdf_report():
     entries = [
-        DummyEntry(datetime.datetime(2025, 7, 1, 9), 7.0, 40, 3.3, 6),
+        DummyEntry(
+            datetime.datetime(2025, 7, 1, 9, tzinfo=datetime.timezone.utc),
+            7.0,
+            40,
+            3.3,
+            6,
+        ),
     ]
     plot_buf = make_sugar_plot(entries, "тест")
     pdf_buf = generate_pdf_report(


### PR DESCRIPTION
## Summary
- ensure freeform handler uses timezone-aware UTC datetimes
- adapt reporting tests to expect timezone-aware events

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_688e739eda58832a9f66b3b4a88b3bb7