### PR TITLE
[gpt] centralize OpenAI client setup

### DIFF
--- a/diabetes/gpt_client.py
+++ b/diabetes/gpt_client.py
@@ -1,27 +1,11 @@
 # gpt_client.py
 
-import openai
-import os
 import logging
-from diabetes.config import OPENAI_API_KEY, OPENAI_ASSISTANT_ID, OPENAI_PROXY
 
-# --- Только здесь прописываем прокси ---
-if OPENAI_PROXY:
-    os.environ["HTTP_PROXY"] = OPENAI_PROXY
-    os.environ["HTTPS_PROXY"] = OPENAI_PROXY
+from diabetes.config import OPENAI_ASSISTANT_ID
+from diabetes.openai_utils import get_openai_client
 
-if not OPENAI_API_KEY:
-    message = "OPENAI_API_KEY is not set"
-    logging.error("[OpenAI] %s", message)
-    raise RuntimeError(message)
-if not OPENAI_ASSISTANT_ID:
-    message = "OPENAI_ASSISTANT_ID is not set"
-    logging.error("[OpenAI] %s", message)
-    raise RuntimeError(message)
-
-client = openai.OpenAI(api_key=OPENAI_API_KEY)
-
-logging.info("[OpenAI] Using assistant: %s", OPENAI_ASSISTANT_ID)
+client = get_openai_client()
 
 
 def create_thread() -> str:

--- a/diabetes/gpt_command_parser.py
+++ b/diabetes/gpt_command_parser.py
@@ -1,24 +1,12 @@
 import asyncio
-import os
 import json
 import logging
 import re
-from openai import OpenAI, OpenAIError
-from diabetes.config import OPENAI_API_KEY, OPENAI_PROXY
+from openai import OpenAIError
 
-# 1️⃣ СРАЗУ ставим переменные окружения — до создания клиента!
-if OPENAI_PROXY:
-    os.environ["HTTP_PROXY"] = OPENAI_PROXY
-    os.environ["HTTPS_PROXY"] = OPENAI_PROXY
+from diabetes.openai_utils import get_openai_client
 
-if not OPENAI_API_KEY:
-    message = "OPENAI_API_KEY is not set"
-    logging.error("[OpenAI] %s", message)
-    raise RuntimeError(message)
-
-# 2️⃣ Создаём обычный клиент OpenAI — без extra‑аргументов,
-#    он возьмёт прокси из env автоматически.
-client = OpenAI(api_key=OPENAI_API_KEY)
+client = get_openai_client()
 
 # gpt_command_parser.py  ← замените весь блок SYSTEM_PROMPT
 SYSTEM_PROMPT = (

--- a/diabetes/openai_utils.py
+++ b/diabetes/openai_utils.py
@@ -1,0 +1,28 @@
+import logging
+import os
+from openai import OpenAI
+from diabetes.config import OPENAI_API_KEY, OPENAI_ASSISTANT_ID, OPENAI_PROXY
+
+
+def get_openai_client() -> OpenAI:
+    """Return a configured OpenAI client.
+
+    Sets proxy environment variables and validates that required
+    credentials are provided.
+    """
+    if OPENAI_PROXY:
+        os.environ["HTTP_PROXY"] = OPENAI_PROXY
+        os.environ["HTTPS_PROXY"] = OPENAI_PROXY
+
+    if not OPENAI_API_KEY:
+        message = "OPENAI_API_KEY is not set"
+        logging.error("[OpenAI] %s", message)
+        raise RuntimeError(message)
+    if not OPENAI_ASSISTANT_ID:
+        message = "OPENAI_ASSISTANT_ID is not set"
+        logging.error("[OpenAI] %s", message)
+        raise RuntimeError(message)
+
+    client = OpenAI(api_key=OPENAI_API_KEY)
+    logging.info("[OpenAI] Using assistant: %s", OPENAI_ASSISTANT_ID)
+    return client

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -4,6 +4,8 @@ import time
 import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+from diabetes import openai_utils  # noqa: F401
 from diabetes import gpt_command_parser
 
 

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -25,6 +25,8 @@ class DummyMessage:
 async def test_profile_command_and_view(monkeypatch, args, expected_icr, expected_cf, expected_target):
     import os
     os.environ["OPENAI_API_KEY"] = "test"
+    os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
+    import diabetes.openai_utils as openai_utils  # noqa: F401
     import diabetes.handlers as handlers
 
     engine = create_engine("sqlite:///:memory:")


### PR DESCRIPTION
## Summary
- create helper to configure OpenAI client with proxy and key validation
- use helper in GPT client and command parser
- update tests to use helper and set required environment variables

## Testing
- `flake8 diabetes/`
- `pytest tests/test_gpt_command_parser.py tests/test_handlers_profile.py`
- `pip install PyPDF2`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_688ecf403990832a8464d15e1b1ba685