### PR TITLE
[handlers] avoid ReplyKeyboardMarkup in edit message

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -324,7 +324,10 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
     if data == "cancel_entry":
         context.user_data.pop('pending_entry', None)
-        await query.edit_message_text("❌ Запись отменена.", reply_markup=menu_keyboard)
+        await query.edit_message_text("❌ Запись отменена.")
+        await query.message.reply_text(
+            "📋 Выберите действие:", reply_markup=menu_keyboard
+        )
         return
 
     # --- Старый код: обработка истории ---
@@ -1088,7 +1091,10 @@ async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_T
     await query.answer()
     data = query.data
     if data == "cancel_entry":
-        await query.edit_message_text("❌ Запрос отменён.", reply_markup=menu_keyboard)
+        await query.edit_message_text("❌ Запрос отменён.")
+        await query.message.reply_text(
+            "📋 Выберите действие:", reply_markup=menu_keyboard
+        )
         context.user_data.pop('awaiting_report_date', None)
         return
     now = datetime.datetime.now()

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -1,0 +1,48 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+
+
+class DummyMessage:
+    def __init__(self):
+        self.replies = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append((text, kwargs))
+
+
+class DummyQuery:
+    def __init__(self, data):
+        self.data = data
+        self.edited = []
+        self.edit_kwargs = []
+        self.message = DummyMessage()
+
+    async def answer(self):
+        pass
+
+    async def edit_message_text(self, text, **kwargs):
+        self.edited.append(text)
+        self.edit_kwargs.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_callback_router_cancel_entry_sends_menu():
+    os.environ["OPENAI_API_KEY"] = "test"
+    os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
+    import diabetes.openai_utils  # noqa: F401
+    import diabetes.handlers as handlers
+
+    query = DummyQuery("cancel_entry")
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace(user_data={"pending_entry": {"telegram_id": 1}})
+
+    await handlers.callback_router(update, context)
+
+    assert query.edited == ["❌ Запись отменена."]
+    assert not query.edit_kwargs[0] or "reply_markup" not in query.edit_kwargs[0]
+    assert len(query.message.replies) == 1
+    text, kwargs = query.message.replies[0]
+    assert kwargs["reply_markup"] == handlers.menu_keyboard
+    assert "pending_entry" not in context.user_data


### PR DESCRIPTION
## Summary
- avoid using ReplyKeyboardMarkup with edit_message_text in callback_router
- fix report_period_callback to send menu keyboard separately
- add regression test for cancel entry routing

## Testing
- `flake8 diabetes/ tests/test_handlers_cancel_entry.py`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_688eda8f0c04832a855117d6dc8f054a