### PR TITLE
[db] Use timezone-aware timestamps

### DIFF
--- a/alembic/versions/1a2b3c4d5e6f_timezone_aware_timestamps.py
+++ b/alembic/versions/1a2b3c4d5e6f_timezone_aware_timestamps.py
@@ -1,0 +1,82 @@
+"""timezone aware timestamps
+
+Revision ID: 1a2b3c4d5e6f
+Revises: de2fbeefa646
+Create Date: 2025-08-03 04:19:02.954662
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1a2b3c4d5e6f'
+down_revision: Union[str, None] = 'de2fbeefa646'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column(
+        'users',
+        'created_at',
+        type_=sa.TIMESTAMP(timezone=True),
+        existing_type=sa.TIMESTAMP(),
+        existing_server_default=sa.text('now()'),
+    )
+
+    op.alter_column(
+        'entries',
+        'event_time',
+        type_=sa.TIMESTAMP(timezone=True),
+        existing_type=sa.TIMESTAMP(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        'entries',
+        'created_at',
+        type_=sa.TIMESTAMP(timezone=True),
+        existing_type=sa.TIMESTAMP(),
+        existing_server_default=sa.text('now()'),
+    )
+    op.alter_column(
+        'entries',
+        'updated_at',
+        type_=sa.TIMESTAMP(timezone=True),
+        existing_type=sa.TIMESTAMP(),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.alter_column(
+        'users',
+        'created_at',
+        type_=sa.TIMESTAMP(),
+        existing_type=sa.TIMESTAMP(timezone=True),
+        existing_server_default=sa.text('now()'),
+    )
+
+    op.alter_column(
+        'entries',
+        'event_time',
+        type_=sa.TIMESTAMP(),
+        existing_type=sa.TIMESTAMP(timezone=True),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        'entries',
+        'created_at',
+        type_=sa.TIMESTAMP(),
+        existing_type=sa.TIMESTAMP(timezone=True),
+        existing_server_default=sa.text('now()'),
+    )
+    op.alter_column(
+        'entries',
+        'updated_at',
+        type_=sa.TIMESTAMP(),
+        existing_type=sa.TIMESTAMP(timezone=True),
+    )

--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -32,7 +32,7 @@ class User(Base):
 
     telegram_id = Column(BigInteger, primary_key=True, index=True)
     thread_id = Column(String, nullable=False)
-    created_at = Column(TIMESTAMP, server_default=func.now())
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now())
 
 
 class Profile(Base):
@@ -55,9 +55,9 @@ class Entry(Base):
     id = Column(Integer, primary_key=True, index=True)
     telegram_id = Column(BigInteger, ForeignKey("users.telegram_id"))
 
-    event_time = Column(TIMESTAMP, nullable=False)  # время приёма
-    created_at = Column(TIMESTAMP, server_default=func.now())
-    updated_at = Column(TIMESTAMP, onupdate=func.now())
+    event_time = Column(TIMESTAMP(timezone=True), nullable=False)  # время приёма
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now())
+    updated_at = Column(TIMESTAMP(timezone=True), onupdate=func.now())
 
     photo_path = Column(String)
     carbs_g = Column(Float)

--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -135,7 +135,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             if "dose" in parts:  entry.dose         = float(parts["dose"])
             if "сахар" in parts or "sugar" in parts:
                 entry.sugar_before = float(parts.get("сахар") or parts["sugar"])
-            entry.updated_at = datetime.datetime.utcnow()
+            entry.updated_at = datetime.datetime.now(datetime.timezone.utc)
             commit_session(s)
         context.user_data.pop("edit_id")
         await update.message.reply_text("✅ Запись обновлена!")
@@ -1017,7 +1017,7 @@ async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_T
         )
         context.user_data.pop('awaiting_report_date', None)
         return
-    now = datetime.datetime.now()
+    now = datetime.datetime.now(datetime.timezone.utc)
     if data == "report_today":
         date_from = now.replace(hour=0, minute=0, second=0, microsecond=0)
         period_label = "сегодня"


### PR DESCRIPTION
## Summary
- use timezone-aware TIMESTAMP columns for event_time, created_at, updated_at
- add Alembic migration converting existing columns
- ensure handlers write timezone-aware datetimes

## Testing
- `flake8 diabetes/`
- `pytest tests/`
- `alembic upgrade head`


------
https://chatgpt.com/codex/tasks/task_e_688ee22bdd88832a9d4198035a088669