### PR TITLE
[handlers] reuse thread id for photo requests

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -725,7 +725,18 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
 
     try:
         # 2. Запуск Vision run
-        thread_id = context.user_data.get("thread_id") or create_thread()
+        thread_id = context.user_data.get("thread_id")
+        if not thread_id:
+            with SessionLocal() as session:
+                user = session.get(User, user_id)
+                if user:
+                    thread_id = user.thread_id
+                else:
+                    thread_id = create_thread()
+                    session.add(User(telegram_id=user_id, thread_id=thread_id))
+                    commit_session(session)
+            context.user_data["thread_id"] = thread_id
+
         run = send_message(
             thread_id=thread_id,
             content="Определи количество углеводов и ХЕ на фото блюда. Используй формат из системных инструкций ассистента.",


### PR DESCRIPTION
## Summary
- cache OpenAI thread id in user data for photo analysis
- fetch thread id from database when missing, creating a record if necessary

## Testing
- `pytest` *(fails: async def functions are not natively supported)*
- `flake8 diabetes`


------
https://chatgpt.com/codex/tasks/task_e_688ee81ec6f8832ab5fceedca8fcb19c