### PR TITLE
[handlers] add per_message flag to conversations

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -1249,6 +1249,7 @@ onboarding_conv = ConversationHandler(
         CommandHandler("cancel", cancel_handler),
         MessageHandler(filters.TEXT & ~filters.COMMAND, freeform_handler)
     ],
+    per_message=True,
 )
 
 sugar_conv = ConversationHandler(
@@ -1263,6 +1264,7 @@ sugar_conv = ConversationHandler(
         CommandHandler("cancel", cancel_handler),
         MessageHandler(filters.TEXT & ~filters.COMMAND, freeform_handler)
     ],
+    per_message=True,
 )
 
 photo_conv = ConversationHandler(
@@ -1279,6 +1281,7 @@ photo_conv = ConversationHandler(
         CommandHandler("cancel", cancel_handler),
         MessageHandler(filters.TEXT & ~filters.COMMAND, freeform_handler)
     ],
+    per_message=True,
 )
 
 dose_conv = ConversationHandler(
@@ -1296,6 +1299,7 @@ dose_conv = ConversationHandler(
         CommandHandler("cancel", cancel_handler),
         MessageHandler(filters.TEXT & ~filters.COMMAND, freeform_handler)
     ],
+    per_message=True,
 )
 
 profile_conv = ConversationHandler(
@@ -1312,6 +1316,7 @@ profile_conv = ConversationHandler(
         CommandHandler("cancel", profile_cancel),
         MessageHandler(filters.TEXT & ~filters.COMMAND, freeform_handler)
     ],
+    per_message=True,
 )
 
 


### PR DESCRIPTION
## Summary
- Explicitly enable per-message tracking for onboarding, sugar, photo, dose, and profile conversations

## Testing
- `flake8 diabetes/handlers.py`
- `pytest -q` *(fails: async def functions are not natively supported; PTBUserWarning about CallbackQueryHandler requirement)*

------
https://chatgpt.com/codex/tasks/task_e_688ef32c8ff4832aa6e76d35509b689d