### PR TITLE
[handlers] Narrow user data reset in history_handler

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -913,7 +913,8 @@ async def history_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     /history                   – последние 5 записей
     /history YYYY‑MM‑DD        – записи за конкретный день
     """
-    context.user_data.clear()
+    for key in ("pending_entry", "awaiting_report_date", "edit_id"):
+        context.user_data.pop(key, None)
     user_id = update.effective_user.id
 
     # ── аргумент‑дата (опционально) ──────────────────────────────


### PR DESCRIPTION
## Summary
- replace blanket `user_data.clear()` in `history_handler` with targeted `pop()` calls

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_688ef4ef87b4832a8a397852f7fb3a04