### PR TITLE
[handlers] allow comma and negative numbers in edits

### DIFF
--- a/diabetes/handlers.py
+++ b/diabetes/handlers.py
@@ -103,15 +103,19 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 reply_markup=confirm_keyboard()
             )
             return
-        parts = dict(re.findall(r"(\w+)\s*=\s*([\d.]+)", text))
+        parts = dict(re.findall(r"(\w+)\s*=\s*([\d.,-]+)", text))
         if not parts:
             await update.message.reply_text("Не вижу ни одного поля для изменения.")
             return
-        if "xe" in parts:    entry['xe']           = float(parts["xe"])
-        if "carbs" in parts: entry['carbs_g']      = float(parts["carbs"])
-        if "dose" in parts:  entry['dose']         = float(parts["dose"])
+        if "xe" in parts:
+            entry['xe'] = float(parts["xe"].replace(",", "."))
+        if "carbs" in parts:
+            entry['carbs_g'] = float(parts["carbs"].replace(",", "."))
+        if "dose" in parts:
+            entry['dose'] = float(parts["dose"].replace(",", "."))
         if "сахар" in parts or "sugar" in parts:
-            entry['sugar_before'] = float(parts.get("сахар") or parts["sugar"])
+            sugar_value = parts.get("сахар") or parts["sugar"]
+            entry['sugar_before'] = float(sugar_value.replace(",", "."))
         carbs = entry.get('carbs_g')
         xe = entry.get('xe')
         sugar = entry.get('sugar_before')
@@ -129,7 +133,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
     if "edit_id" in context.user_data:
         text = update.message.text.lower()
-        parts = dict(re.findall(r"(\w+)\s*=\s*([\d.]+)", text))
+        parts = dict(re.findall(r"(\w+)\s*=\s*([\d.,-]+)", text))
         if not parts:
             await update.message.reply_text("Не вижу ни одного поля для изменения.")
             return
@@ -139,11 +143,15 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 await update.message.reply_text("Запись уже удалена.")
                 context.user_data.pop("edit_id")
                 return
-            if "xe" in parts:    entry.xe           = float(parts["xe"])
-            if "carbs" in parts: entry.carbs_g      = float(parts["carbs"])
-            if "dose" in parts:  entry.dose         = float(parts["dose"])
+            if "xe" in parts:
+                entry.xe = float(parts["xe"].replace(",", "."))
+            if "carbs" in parts:
+                entry.carbs_g = float(parts["carbs"].replace(",", "."))
+            if "dose" in parts:
+                entry.dose = float(parts["dose"].replace(",", "."))
             if "сахар" in parts or "sugar" in parts:
-                entry.sugar_before = float(parts.get("сахар") or parts["sugar"])
+                sugar_value = parts.get("сахар") or parts["sugar"]
+                entry.sugar_before = float(sugar_value.replace(",", "."))
             entry.updated_at = datetime.datetime.now(datetime.timezone.utc)
             commit_session(s)
         context.user_data.pop("edit_id")

--- a/tests/test_handlers_freeform_numbers.py
+++ b/tests/test_handlers_freeform_numbers.py
@@ -1,0 +1,40 @@
+import re
+
+
+def parse_values(text: str) -> dict[str, float]:
+    parts = dict(re.findall(r"(\w+)\s*=\s*([\d.,-]+)", text))
+    result = {}
+    if "xe" in parts:
+        result["xe"] = float(parts["xe"].replace(",", "."))
+    if "carbs" in parts:
+        result["carbs"] = float(parts["carbs"].replace(",", "."))
+    if "dose" in parts:
+        result["dose"] = float(parts["dose"].replace(",", "."))
+    if "sugar" in parts:
+        result["sugar"] = float(parts["sugar"].replace(",", "."))
+    if "сахар" in parts:
+        result["sugar"] = float(parts["сахар"].replace(",", "."))
+    return result
+
+
+def test_parse_comma_and_negative_values():
+    text = "carbs=10,5 dose=-1,5 xe=2 sugar=5,6"
+    parsed = parse_values(text)
+    assert parsed == {
+        "carbs": 10.5,
+        "dose": -1.5,
+        "xe": 2.0,
+        "sugar": 5.6,
+    }
+
+
+def test_parse_negative_numbers():
+    text = "carbs=-10.5 dose=-2 xe=-1,0 sugar=-4,2"
+    parsed = parse_values(text)
+    assert parsed == {
+        "carbs": -10.5,
+        "dose": -2.0,
+        "xe": -1.0,
+        "sugar": -4.2,
+    }
+


### PR DESCRIPTION
## Summary
- allow freeform edits to parse numbers with commas and negative values
- test parsing of comma-separated and negative numbers

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_688ef4afa678832a8b84d33cf14431da