### PR TITLE
[functions] Support ± ranges in nutrition parsing

### DIFF
--- a/diabetes/functions.py
+++ b/diabetes/functions.py
@@ -94,12 +94,23 @@ def extract_nutrition_info(text: str) -> tuple[float | None, float | None]:
     """
     carbs = xe = None
     # Парсим углеводы (carbs)
-    m = re.search(r"углевод[^\d]*:\s*([\d.,]+)\s*г", text, re.IGNORECASE)
+    m = re.search(
+        r"углевод[^\d]*:\s*(\d+[.,]?\d*)\s*(?:г)?\s*±\s*(\d+[.,]?\d*)\s*г",
+        text,
+        re.IGNORECASE,
+    )
     if m:
-        carbs = _safe_float(m.group(1))
-    # Диапазон XE c двоеточием (например XE: 2–3)
+        first = _safe_float(m.group(1))
+        second = _safe_float(m.group(2))
+        if first is not None and second is not None:
+            carbs = (first - second + first + second) / 2
+    else:
+        m = re.search(r"углевод[^\d]*:\s*([\d.,]+)\s*г", text, re.IGNORECASE)
+        if m:
+            carbs = _safe_float(m.group(1))
+    # Диапазон XE c двоеточием (например XE: 2±1 или XE: 2–3)
     rng = re.search(
-        r"\b(?:[хx][еe]|xe)\s*:\s*(\d+[.,]?\d*)\s*[–-]\s*(\d+[.,]?\d*)",
+        r"\b(?:[хx][еe]|xe)\s*:\s*(\d+[.,]?\d*)\s*±\s*(\d+[.,]?\d*)",
         text,
         re.IGNORECASE,
     )
@@ -107,29 +118,62 @@ def extract_nutrition_info(text: str) -> tuple[float | None, float | None]:
         first = _safe_float(rng.group(1))
         second = _safe_float(rng.group(2))
         if first is not None and second is not None:
-            xe = (first + second) / 2
+            xe = (first - second + first + second) / 2
     else:
-        # Одинарное значение XE: 3.1
-        m = re.search(
-            r"\b(?:[хx][еe]|xe)\s*:\s*([\d.,]+)",
+        rng = re.search(
+            r"\b(?:[хx][еe]|xe)\s*:\s*(\d+[.,]?\d*)\s*[–-]\s*(\d+[.,]?\d*)",
             text,
             re.IGNORECASE,
         )
-        if m:
-            xe = _safe_float(m.group(1))
-        # Диапазон XE без двоеточия (например 2–3 ХЕ)
-        if xe is None:
-            rng = re.search(
-                r"(\d+[.,]?\d*)\s*[–-]\s*(\d+[.,]?\d*)\s*(?:[хx][еe]|xe)",
+        if rng:
+            first = _safe_float(rng.group(1))
+            second = _safe_float(rng.group(2))
+            if first is not None and second is not None:
+                xe = (first + second) / 2
+        else:
+            # Одинарное значение XE: 3.1
+            m = re.search(
+                r"\b(?:[хx][еe]|xe)\s*:\s*([\d.,]+)",
                 text,
                 re.IGNORECASE,
             )
-            if rng:
-                first = _safe_float(rng.group(1))
-                second = _safe_float(rng.group(2))
-                if first is not None and second is not None:
-                    xe = (first + second) / 2
+            if m:
+                xe = _safe_float(m.group(1))
+            # Диапазон XE без двоеточия (например 2±1 ХЕ или 2–3 ХЕ)
+            if xe is None:
+                rng = re.search(
+                    r"(\d+[.,]?\d*)\s*±\s*(\d+[.,]?\d*)\s*(?:[хx][еe]|xe)",
+                    text,
+                    re.IGNORECASE,
+                )
+                if rng:
+                    first = _safe_float(rng.group(1))
+                    second = _safe_float(rng.group(2))
+                    if first is not None and second is not None:
+                        xe = (first - second + first + second) / 2
+            if xe is None:
+                rng = re.search(
+                    r"(\d+[.,]?\d*)\s*[–-]\s*(\d+[.,]?\d*)\s*(?:[хx][еe]|xe)",
+                    text,
+                    re.IGNORECASE,
+                )
+                if rng:
+                    first = _safe_float(rng.group(1))
+                    second = _safe_float(rng.group(2))
+                    if first is not None and second is not None:
+                        xe = (first + second) / 2
     # Диапазон углеводов (carbs) если не найдено
+    if carbs is None:
+        rng = re.search(
+            r"(\d+[.,]?\d*)\s*(?:г)?\s*±\s*(\d+[.,]?\d*)\s*г",
+            text,
+            re.IGNORECASE,
+        )
+        if rng:
+            first = _safe_float(rng.group(1))
+            second = _safe_float(rng.group(2))
+            if first is not None and second is not None:
+                carbs = (first - second + first + second) / 2
     if carbs is None:
         rng = re.search(
             r"(\d+[.,]?\d*)\s*[–-]\s*(\d+[.,]?\d*)\s*г",

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -72,6 +72,20 @@ def test_extract_nutrition_info_ranges():
     assert carbs == 40  # (30+50)/2
     assert xe == 2.5    # (2+3)/2
 
+
+def test_extract_nutrition_info_plus_minus():
+    text = "углеводы: 45 г ± 5 г, XE: 3 ± 0.5"
+    carbs, xe = extract_nutrition_info(text)
+    assert carbs == 45
+    assert xe == 3
+
+
+def test_extract_nutrition_info_plus_minus_no_colon():
+    text = "В блюде 30 г ± 10 г углеводов и 2 ± 1 ХЕ"
+    carbs, xe = extract_nutrition_info(text)
+    assert carbs == 30
+    assert xe == 2
+
 def test_extract_nutrition_info_missing():
     text = "Нет данных"
     carbs, xe = extract_nutrition_info(text)


### PR DESCRIPTION
## Summary
- detect `±` ranges for carbs and XE in `extract_nutrition_info`
- compute average from plus/minus values
- add unit tests covering plus/minus parsing

## Testing
- `flake8 diabetes/`
- `pytest tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_688ef67593d0832a8b161a38263b6b67