### PR TITLE
[gpt_client] Make client initialization thread-safe

### DIFF
--- a/diabetes/gpt_client.py
+++ b/diabetes/gpt_client.py
@@ -1,17 +1,21 @@
 # gpt_client.py
 
 import logging
+import threading
 
 from diabetes.config import OPENAI_ASSISTANT_ID
 from diabetes.openai_utils import get_openai_client
 
 _client = None
+_client_lock = threading.Lock()
 
 
 def _get_client():
     global _client
     if _client is None:
-        _client = get_openai_client()
+        with _client_lock:
+            if _client is None:
+                _client = get_openai_client()
     return _client
 
 

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -1,0 +1,31 @@
+import threading
+import time
+
+from diabetes import gpt_client
+
+
+def test_get_client_thread_safe(monkeypatch):
+    fake_client = object()
+    call_count = 0
+
+    def fake_get_openai_client():
+        nonlocal call_count
+        time.sleep(0.01)
+        call_count += 1
+        return fake_client
+
+    monkeypatch.setattr(gpt_client, "get_openai_client", fake_get_openai_client)
+    monkeypatch.setattr(gpt_client, "_client", None)
+    results = []
+
+    def worker():
+        results.append(gpt_client._get_client())
+
+    threads = [threading.Thread(target=worker) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert call_count == 1
+    assert all(r is fake_client for r in results)


### PR DESCRIPTION
## Summary
- protect OpenAI client creation with a lock to avoid race conditions
- add regression test exercising concurrent `_get_client` calls

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_688ef6bd00b0832a821526a08b32b681