### PR TITLE
[gpt_command_parser] lazy-load OpenAI client

### DIFF
--- a/diabetes/gpt_command_parser.py
+++ b/diabetes/gpt_command_parser.py
@@ -4,9 +4,7 @@ import logging
 import re
 from openai import OpenAIError
 
-from diabetes.openai_utils import get_openai_client
-
-client = get_openai_client()
+from diabetes.gpt_client import _get_client
 
 # gpt_command_parser.py  ← замените весь блок SYSTEM_PROMPT
 SYSTEM_PROMPT = (
@@ -65,7 +63,7 @@ async def parse_command(text: str, timeout: float = 10) -> dict | None:
     try:
         response = await asyncio.wait_for(
             asyncio.to_thread(
-                client.chat.completions.create,
+                _get_client().chat.completions.create,
                 model="gpt-4o-mini",
                 messages=[
                     {"role": "system", "content": SYSTEM_PROMPT},


### PR DESCRIPTION
## Summary
- Avoid importing and instantiating the OpenAI client at module load in gpt_command_parser
- Update parse_command to grab the client lazily
- Patch tests to mock the client via helper function

## Testing
- `flake8 diabetes/`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_688efbb19818832ab640156650dd5102