### PR TITLE
[db] Disable autocommit and autoflush for SessionLocal

### DIFF
--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -22,7 +22,7 @@ DATABASE_URL = URL.create(
 )
 
 engine = create_engine(DATABASE_URL)
-SessionLocal = sessionmaker(bind=engine)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 Base = declarative_base()
 
 

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -31,7 +31,7 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
-    TestSession = sessionmaker(bind=engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
     monkeypatch.setattr(handlers, "SessionLocal", TestSession)
 


### PR DESCRIPTION
## Summary
- prevent implicit commits/flushes by disabling autocommit and autoflush in SessionLocal
- adjust profile handler test to use the same sessionmaker options

## Testing
- `flake8 diabetes/`
- `pytest tests/test_handlers_profile.py tests/test_handlers_commit_failures.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f05acbea8832abaee5b314b9f483f