### PR TITLE
[profile_handlers] ensure profile coefficients are positive

### DIFF
--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -28,41 +28,49 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         icr = float(args[0].replace(",", "."))
         cf = float(args[1].replace(",", "."))
         target = float(args[2].replace(",", "."))
-
-        warning_msg = ""
-        if icr > 8 or cf < 3:
-            warning_msg = (
-                "\n⚠️ Проверьте, пожалуйста: возможно, вы перепутали местами ИКХ и КЧ.\n"
-                f"• Вы ввели ИКХ = {icr} г/ед. (высоковато)\n"
-                f"• КЧ = {cf} ммоль/л (низковато)\n\n"
-                "Если вы хотели ввести наоборот, отправьте:\n"
-                f"/profile {cf} {icr} {target}\n"
-            )
-
-        user_id = update.effective_user.id
-        with SessionLocal() as session:
-            prof = session.get(Profile, user_id)
-            if not prof:
-                prof = Profile(telegram_id=user_id)
-                session.add(prof)
-
-            prof.icr = icr
-            prof.cf = cf
-            prof.target_bg = target
-            commit_session(session)
-
-        await update.message.reply_text(
-            f"✅ Профиль обновлён:\n"
-            f"• ИКХ: {icr} г/ед.\n"
-            f"• КЧ: {cf} ммоль/л\n"
-            f"• Целевой сахар: {target} ммоль/л" + warning_msg,
-            parse_mode="Markdown",
-        )
     except ValueError:
         await update.message.reply_text(
             "❗ Пожалуйста, введите корректные числа. Пример:\n/profile 10 2 6",
             parse_mode="Markdown",
         )
+        return
+
+    if icr <= 0 or cf <= 0 or target <= 0:
+        await update.message.reply_text(
+            "❗ Все значения должны быть больше 0. Пример:\n/profile 10 2 6",
+            parse_mode="Markdown",
+        )
+        return
+
+    warning_msg = ""
+    if icr > 8 or cf < 3:
+        warning_msg = (
+            "\n⚠️ Проверьте, пожалуйста: возможно, вы перепутали местами ИКХ и КЧ.\n"
+            f"• Вы ввели ИКХ = {icr} г/ед. (высоковато)\n"
+            f"• КЧ = {cf} ммоль/л (низковато)\n\n"
+            "Если вы хотели ввести наоборот, отправьте:\n"
+            f"/profile {cf} {icr} {target}\n"
+        )
+
+    user_id = update.effective_user.id
+    with SessionLocal() as session:
+        prof = session.get(Profile, user_id)
+        if not prof:
+            prof = Profile(telegram_id=user_id)
+            session.add(prof)
+
+        prof.icr = icr
+        prof.cf = cf
+        prof.target_bg = target
+        commit_session(session)
+
+    await update.message.reply_text(
+        f"✅ Профиль обновлён:\n"
+        f"• ИКХ: {icr} г/ед.\n"
+        f"• КЧ: {cf} ммоль/л\n"
+        f"• Целевой сахар: {target} ммоль/л" + warning_msg,
+        parse_mode="Markdown",
+    )
 
 
 async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -2,6 +2,7 @@ import pytest
 from types import SimpleNamespace
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from unittest.mock import MagicMock
 
 from diabetes.db import Base, User
 
@@ -56,3 +57,36 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
     assert f"ИКХ: {expected_icr} г/ед." in message2.texts[0]
     assert f"КЧ: {expected_cf} ммоль/л" in message2.texts[0]
     assert f"Целевой сахар: {expected_target} ммоль/л" in message2.texts[0]
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["0", "3", "6"],
+        ["8", "0", "6"],
+        ["8", "3", "-1"],
+    ],
+)
+@pytest.mark.asyncio
+async def test_profile_command_invalid_values(monkeypatch, args):
+    import os
+
+    os.environ["OPENAI_API_KEY"] = "test"
+    os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
+    import diabetes.openai_utils as openai_utils  # noqa: F401
+    import diabetes.profile_handlers as handlers
+
+    commit_mock = MagicMock()
+    session_local_mock = MagicMock()
+    monkeypatch.setattr(handlers, "commit_session", commit_mock)
+    monkeypatch.setattr(handlers, "SessionLocal", session_local_mock)
+
+    message = DummyMessage()
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(args=args, user_data={})
+
+    await handlers.profile_command(update, context)
+
+    assert commit_mock.call_count == 0
+    assert session_local_mock.call_count == 0
+    assert any("больше 0" in t for t in message.texts)


### PR DESCRIPTION
## Summary
- validate parsed profile coefficients are positive before saving
- test invalid profile values to avoid DB commits

## Testing
- `flake8 diabetes/ tests/test_handlers_profile.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f1043e168832abadfa6da85ff0b40