### PR TITLE
[dose_handlers] handle missing document mime type

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -317,7 +317,11 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
 async def doc_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handle images sent as documents."""
     document = update.message.document
-    if not document or not document.mime_type.startswith("image/"):
+    if not document:
+        return ConversationHandler.END
+
+    mime_type = document.mime_type
+    if not mime_type or not mime_type.startswith("image/"):
         return ConversationHandler.END
 
     user_id = update.effective_user.id


### PR DESCRIPTION
## Summary
- avoid calling `.startswith` on missing document MIME types
- test `doc_handler` returns early when MIME type is absent

## Testing
- `flake8 diabetes/`
- `pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_688f12b6a400832aa8c464fbb2065b1a