### PR TITLE
[gpt_client] Add option to keep uploaded images

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -232,6 +232,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
                 "Используй формат из системных инструкций ассистента."
             ),
             image_path=file_path,
+            keep_image=True,
         )
         await message.reply_text("🔍 Анализирую фото (это займёт 5‑10 с)…")
 


### PR DESCRIPTION
## Summary
- allow `gpt_client.send_message` to keep or delete uploaded images via `keep_image`
- ensure `photo_handler` preserves user photo files
- cover photo preservation with a new test

## Testing
- `flake8 diabetes/`
- `pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_688f1fd179ec832a926e356a7692d8df