### PR TITLE
[profile] preserve context data on profile view

### DIFF
--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -75,7 +75,6 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
 async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Display current patient profile."""
-    context.user_data.clear()
     user_id = update.effective_user.id
     with SessionLocal() as session:
         profile = session.get(Profile, user_id)


### PR DESCRIPTION
## Summary
- avoid wiping `user_data` when viewing a profile so other handler state persists
- test that arbitrary keys like `thread_id` survive `profile_view`

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_688f22b5aa88832a944f21f927b1726a