### PR TITLE
[profile] clarify insulin ratio label

### DIFF
--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -91,7 +91,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
     msg = (
         "📄 Ваш профиль:\n"
-        f"• ИКХ: {profile.icr} г/ед.\n"
+        f"• ИКХ: {profile.icr} г/ед.\n"  # Инсулин-карб коэффициент
         f"• КЧ: {profile.cf} ммоль/л\n"
         f"• Целевой сахар: {profile.target_bg} ммоль/л"
     )

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -45,18 +45,18 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
     context = SimpleNamespace(args=args, user_data={})
 
     await handlers.profile_command(update, context)
-    assert f"ИКХ: {expected_icr} г/ед." in message.texts[0]
-    assert f"КЧ: {expected_cf} ммоль/л" in message.texts[0]
-    assert f"Целевой сахар: {expected_target} ммоль/л" in message.texts[0]
+    assert f"• ИКХ: {expected_icr} г/ед." in message.texts[0]
+    assert f"• КЧ: {expected_cf} ммоль/л" in message.texts[0]
+    assert f"• Целевой сахар: {expected_target} ммоль/л" in message.texts[0]
 
     message2 = DummyMessage()
     update2 = SimpleNamespace(message=message2, effective_user=SimpleNamespace(id=123))
     context2 = SimpleNamespace(user_data={})
 
     await handlers.profile_view(update2, context2)
-    assert f"ИКХ: {expected_icr} г/ед." in message2.texts[0]
-    assert f"КЧ: {expected_cf} ммоль/л" in message2.texts[0]
-    assert f"Целевой сахар: {expected_target} ммоль/л" in message2.texts[0]
+    assert f"• ИКХ: {expected_icr} г/ед." in message2.texts[0]
+    assert f"• КЧ: {expected_cf} ммоль/л" in message2.texts[0]
+    assert f"• Целевой сахар: {expected_target} ммоль/л" in message2.texts[0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- clarify that profile view displays the ИКХ ratio
- adjust profile text tests to expect bullet-prefixed labels

## Testing
- `python -m flake8 diabetes tests/test_handlers_profile.py`
- `python -m pytest tests/test_handlers_profile.py`

------
https://chatgpt.com/codex/tasks/task_e_688f25291300832aa8ecfa185aef7f20