### PR TITLE
[dose] remove unused dose state constants

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -21,9 +21,7 @@ from diabetes.ui import menu_keyboard, confirm_keyboard
 from .common_handlers import commit_session
 from .reporting_handlers import send_report
 
-DOSE_METHOD, DOSE_XE, DOSE_SUGAR, DOSE_CARBS = range(3, 7)
 PHOTO_SUGAR = 7
-SUGAR_VAL = 8
 WAITING_GPT_FLAG = "waiting_gpt_response"
 
 
@@ -333,12 +331,7 @@ async def doc_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 __all__ = [
-    "DOSE_METHOD",
-    "DOSE_XE",
-    "DOSE_SUGAR",
-    "DOSE_CARBS",
     "PHOTO_SUGAR",
-    "SUGAR_VAL",
     "WAITING_GPT_FLAG",
     "freeform_handler",
     "photo_handler",


### PR DESCRIPTION
## Summary
- drop unused conversation state constants from insulin dose handlers
- clean up module exports

## Testing
- `python -m pytest tests` *(fails: async def functions are not natively supported)*
- `flake8 diabetes`


------
https://chatgpt.com/codex/tasks/task_e_688f26c6d3c0832abf38fa00f5aded7c