### PR TITLE
[tests] Remove duplicate datetime import

### DIFF
--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -1,5 +1,4 @@
 import datetime
-import datetime
 import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary
- simplify commit failure tests by removing redundant datetime import

## Testing
- `flake8 tests/test_handlers_commit_failures.py`
- `pytest tests/test_handlers_commit_failures.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f28b61364832a829ede25ac45c98d