### PR TITLE
[common_handlers] raise custom commit error and handle

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -18,7 +18,7 @@ from diabetes.functions import extract_nutrition_info
 from diabetes.gpt_client import create_thread, send_message, _get_client
 from diabetes.gpt_command_parser import parse_command
 from diabetes.ui import menu_keyboard, confirm_keyboard
-from .common_handlers import commit_session
+from .common_handlers import CommitError, commit_session
 from .reporting_handlers import send_report
 
 PHOTO_SUGAR = 7
@@ -108,7 +108,11 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 sugar_value = parts.get("сахар") or parts["sugar"]
                 entry.sugar_before = float(sugar_value.replace(",", "."))
             entry.updated_at = datetime.datetime.now(datetime.timezone.utc)
-            commit_session(session)
+            try:
+                commit_session(session)
+            except CommitError:
+                await update.message.reply_text("⚠️ Не удалось обновить запись.")
+                return
         context.user_data.pop("edit_id")
         await update.message.reply_text("✅ Запись обновлена!")
         return
@@ -220,7 +224,13 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
                 else:
                     thread_id = create_thread()
                     session.add(User(telegram_id=user_id, thread_id=thread_id))
-                    commit_session(session)
+                    try:
+                        commit_session(session)
+                    except CommitError:
+                        await message.reply_text(
+                            "⚠️ Не удалось сохранить данные пользователя."
+                        )
+                        return ConversationHandler.END
             context.user_data["thread_id"] = thread_id
 
         run = send_message(

--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -7,7 +7,7 @@ from telegram.ext import ContextTypes, ConversationHandler
 
 from diabetes.db import SessionLocal, Profile
 from diabetes.ui import menu_keyboard
-from .common_handlers import commit_session
+from .common_handlers import CommitError, commit_session
 
 PROFILE_ICR, PROFILE_CF, PROFILE_TARGET = range(0, 3)
 
@@ -62,7 +62,11 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         prof.icr = icr
         prof.cf = cf
         prof.target_bg = target
-        commit_session(session)
+        try:
+            commit_session(session)
+        except CommitError:
+            await update.message.reply_text("⚠️ Не удалось сохранить профиль.")
+            return
 
     await update.message.reply_text(
         f"✅ Профиль обновлён:\n"

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -52,11 +52,11 @@ async def test_profile_command_commit_failure(monkeypatch, caplog):
     context = SimpleNamespace(args=["10", "2", "6"], user_data={})
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(SQLAlchemyError):
-            await profile_handlers.profile_command(update, context)
+        await profile_handlers.profile_command(update, context)
 
     assert session.rollback.called
     assert "DB commit failed" in caplog.text
+    assert message.texts == ["⚠️ Не удалось сохранить профиль."]
 
 
 @pytest.mark.asyncio
@@ -85,9 +85,8 @@ async def test_callback_router_commit_failure(monkeypatch, caplog):
     context = SimpleNamespace(user_data={"pending_entry": pending_entry})
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(SQLAlchemyError):
-            await common_handlers.callback_router(update, context)
+        await common_handlers.callback_router(update, context)
 
     assert session.rollback.called
     assert "DB commit failed" in caplog.text
-    assert not query.edited  # message was not edited due to failure
+    assert query.edited == ["⚠️ Не удалось сохранить запись."]


### PR DESCRIPTION
## Summary
- add `CommitError` and raise it from `commit_session`
- handle commit failures in dose and profile handlers and callback router
- update commit failure tests for new exception

## Testing
- `python -m flake8 diabetes`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_688f2d4f285c832ab43929447b7e9637