### PR TITLE
[gpt_command_parser] tighten API key masking

### DIFF
--- a/diabetes/gpt_command_parser.py
+++ b/diabetes/gpt_command_parser.py
@@ -41,7 +41,13 @@ SYSTEM_PROMPT = (
 
 def _sanitize_sensitive_data(text: str) -> str:
     """Mask potentially sensitive tokens in *text* before logging."""
-    return re.sub(r"[A-Za-z0-9]{32,}", "[REDACTED]", text)
+    api_key_pattern = (
+        r"\b(?=[A-Za-z0-9_-]*[a-z])"
+        r"(?=[A-Za-z0-9_-]*[A-Z])"
+        r"(?=[A-Za-z0-9_-]*\d)"
+        r"[A-Za-z0-9_-]{40,}\b"
+    )
+    return re.sub(api_key_pattern, "[REDACTED]", text)
 
 
 def _extract_first_json(text: str) -> dict | None:


### PR DESCRIPTION
## Summary
- strengthen sensitive token regex to require mixed case, digits, underscores or hyphens and length ≥40
- add tests confirming API-like tokens are redacted while long numeric strings are not

## Testing
- `python -m flake8 diabetes/ tests/test_gpt_command_parser.py`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_688f3b62eae0832abe2b67d745b802bd