### PR TITLE
[dose_handlers] Sanitize Vision logs

### DIFF
--- a/tests/test_dose_handlers_logging.py
+++ b/tests/test_dose_handlers_logging.py
@@ -1,0 +1,14 @@
+import logging
+
+from diabetes import dose_handlers
+
+
+def test_logging_truncates_content(caplog):
+    long_text = "A" * 250 + "\x00\x01"
+    with caplog.at_level(logging.DEBUG):
+        dose_handlers.logger.debug("test %s", dose_handlers._sanitize(long_text))
+    record = caplog.records[0]
+    assert "A" * 200 in record.message
+    assert "A" * 201 not in record.message
+    assert "\x00" not in record.message
+    assert "\x01" not in record.message


### PR DESCRIPTION
## Summary
- sanitize Vision content before logging and limit log size
- replace Vision `logging.warning` statements with `logger` calls
- add unit test verifying log truncation

## Testing
- `flake8 diabetes/`
- `pytest tests/test_dose_handlers_logging.py::test_logging_truncates_content -q`
- `pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3d2939fc832aa4003c675f28cc6b