### PR TITLE
[reporting] Flag extreme sugar levels in PDF reports

### DIFF
--- a/diabetes/reporting_handlers.py
+++ b/diabetes/reporting_handlers.py
@@ -8,6 +8,9 @@ from telegram.ext import ContextTypes
 from diabetes.db import SessionLocal, Entry
 from diabetes.reporting import make_sugar_plot, generate_pdf_report
 
+LOW_SUGAR_THRESHOLD = 3.0
+HIGH_SUGAR_THRESHOLD = 13.0
+
 
 async def send_report(update: Update, context: ContextTypes.DEFAULT_TYPE, date_from, period_label, query=None) -> None:
     """Generate and send a PDF report for entries after ``date_from``."""
@@ -39,6 +42,11 @@ async def send_report(update: Update, context: ContextTypes.DEFAULT_TYPE, date_f
         dose = entry.dose if entry.dose is not None else "—"
         line = f"{day_str}: сахар {sugar}, углеводы {carbs}, доза {dose}"
         day_lines.append(line)
+        if entry.sugar_before is not None:
+            if entry.sugar_before < LOW_SUGAR_THRESHOLD:
+                errors.append(f"{day_str}: низкий сахар {entry.sugar_before}")
+            elif entry.sugar_before > HIGH_SUGAR_THRESHOLD:
+                errors.append(f"{day_str}: высокий сахар {entry.sugar_before}")
 
     gpt_text = "Ваши данные проанализированы. Рекомендации GPT могут быть добавлены тут."
     report_msg = "<b>Отчёт сформирован</b>\n\n" + "\n".join(summary_lines + day_lines)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -42,7 +42,7 @@ def test_generate_pdf_report():
     entries = [
         DummyEntry(
             datetime.datetime(2025, 7, 1, 9, tzinfo=datetime.timezone.utc),
-            7.0,
+            15.0,
             40,
             3.3,
             6,
@@ -51,14 +51,16 @@ def test_generate_pdf_report():
     plot_buf = make_sugar_plot(entries, "тест")
     pdf_buf = generate_pdf_report(
         summary_lines=["Всего записей: 1"],
-        errors=[],
-        day_lines=["01.07: сахар 7.0–7.0, доза 6, углеводы 40"],
+        errors=["01.07: высокий сахар 15.0"],
+        day_lines=["01.07: сахар 15.0, доза 6, углеводы 40"],
         gpt_text="Всё хорошо.",
         plot_buf=plot_buf
     )
     assert hasattr(pdf_buf, 'read')
     pdf_buf.seek(0)
-    assert len(pdf_buf.read()) > 1000
+    reader = PdfReader(pdf_buf)
+    text = "".join(page.extract_text() for page in reader.pages)
+    assert "высокий сахар 15.0" in text
 
 
 @pytest.mark.parametrize("block", ["summary_lines", "errors", "day_lines"])


### PR DESCRIPTION
## Summary
- flag low and high sugar readings while building day report
- test PDF report generation with an error section

## Testing
- `flake8 diabetes`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_688f3ee76e24832aaf06208970885e8b