### PR TITLE
Preserve pending entries during manual edits

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -55,8 +55,6 @@ menu_keyboard = ReplyKeyboardMarkup(
 
 # ──────────────────────────────────────────────────────────────
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    # Сбросить старую pending_entry, если есть
-    context.user_data.pop('pending_entry', None)
     raw_text = update.message.text.strip()
     user_id  = update.effective_user.id
     logger.info(f"FREEFORM raw='{raw_text}'  user={user_id}")
@@ -149,8 +147,12 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             entry.updated_at = datetime.utcnow()
             s.commit()
         context.user_data.pop("edit_id")
+        context.user_data.pop('pending_entry', None)
         await update.message.reply_text("✅ Запись обновлена!")
         return
+
+    # Сбросить старую pending_entry, если начинаем новую запись
+    context.user_data.pop('pending_entry', None)
 
     # --- основной freeform ---
     parsed = await parse_command(raw_text)


### PR DESCRIPTION
## Summary
- retain `pending_entry` at start of `freeform_handler` so manual edits aren't lost
- clear `pending_entry` only after editing existing entries or before starting new ones

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f42e7eae8832a99295d7083526226