### PR TITLE
[dose_handlers] Ensure report date is timezone-aware

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -43,7 +43,9 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if context.user_data.get("awaiting_report_date"):
         try:
-            date_from = datetime.datetime.strptime(update.message.text.strip(), "%Y-%m-%d")
+            date_from = datetime.datetime.strptime(
+                update.message.text.strip(), "%Y-%m-%d"
+            ).replace(tzinfo=datetime.timezone.utc)
         except ValueError:
             await update.message.reply_text("❗ Некорректная дата. Используйте формат YYYY-MM-DD.")
             return


### PR DESCRIPTION
## Summary
- Make report date parsed in freeform handler timezone-aware before generating reports

## Testing
- `flake8 diabetes/`
- `pytest tests/test_reporting.py`


------
https://chatgpt.com/codex/tasks/task_e_688f45f0efc8832a83325452aaf3382e