### PR TITLE
Ensure pytest imports in tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,17 +1,14 @@
 import pytest
-from api import ai_diagnose, DiagnoseRequest
 
+from api import ai_diagnose, DiagnoseRequest
 
 @pytest.mark.asyncio
 async def test_ai_diagnose_with_protocol():
     result = await ai_diagnose(DiagnoseRequest(diagnosis="диабет 2 типа"))
     assert result["protocol"] == "standard protocol"
 
-
 @pytest.mark.asyncio
 async def test_ai_diagnose_without_protocol():
     result = await ai_diagnose(DiagnoseRequest(diagnosis="unknown"))
     assert result["protocol"] is None
-
-
 

--- a/tests/test_bot_photo.py
+++ b/tests/test_bot_photo.py
@@ -1,4 +1,5 @@
 import pytest
+
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -23,6 +24,3 @@ async def test_photo_handler_mock_mode(tmp_path):
 
     message.reply_text.assert_any_call("🔍 Анализирую фото (это займёт 5‑10 с)…")
     assert result == PHOTO_SUGAR
-
-
-

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,4 +1,5 @@
 import pytest
+
 from stubs.bot_stub import extract_nutrition_info
 from functions import calc_bolus, PatientProfile
 


### PR DESCRIPTION
## Summary
- group imports and ensure `pytest` is explicitly imported at top of test modules

## Testing
- `pytest tests/test_api.py tests/test_parsing.py tests/test_bot_photo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688f51f528c0832aad83ac8e8aab4ab6