### PR TITLE
[gpt_command_parser] Handle missing GPT response choices

### DIFF
--- a/diabetes/gpt_command_parser.py
+++ b/diabetes/gpt_command_parser.py
@@ -80,7 +80,11 @@ async def parse_command(text: str, timeout: float = 10) -> dict | None:
             ),
             timeout=timeout,
         )
-        content = response.choices[0].message.content.strip()
+        choices = getattr(response, "choices", None)
+        if not choices:
+            logging.error("No choices in GPT response")
+            return None
+        content = choices[0].message.content.strip()
         safe_content = _sanitize_sensitive_data(content)
         logging.info("GPT raw response: %s", safe_content[:200])
         parsed = _extract_first_json(content)


### PR DESCRIPTION
## Summary
- guard against empty `choices` when parsing GPT command responses

## Testing
- `flake8 diabetes/`
- `pytest tests` *(fails: ModuleNotFoundError or error in tests)*

------
https://chatgpt.com/codex/tasks/task_e_688f64dde42c832a8603932494735687