### PR TITLE
[deps] Add PyPDF2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pillow==11.2.1
 psycopg2-binary==2.9.6
 pydantic==2.11.4
 pydantic_core==2.33.2
+PyPDF2==3.0.1
 pyparsing==3.2.3
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- include PyPDF2 in requirements

## Testing
- `flake8 diabetes`
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_688f662ae318832ab606063bf43297d6