### PR TITLE
test: add pytest-asyncio dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,8 @@ psycopg2-binary==2.9.6
 pydantic==2.11.4
 pydantic_core==2.33.2
 pyparsing==3.2.3
+pytest==8.4.1
+pytest-asyncio==1.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 python-telegram-bot==20.4


### PR DESCRIPTION
## Summary
- add pytest and pytest-asyncio to requirements for async tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*
- `pytest tests/test_handlers_profile.py`


------
https://chatgpt.com/codex/tasks/task_e_688f672039b8832abf772d7b284417c6