### PR TITLE
[deps] Replace PyPDF2 with pypdf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pillow==11.2.1
 psycopg2-binary==2.9.6
 pydantic==2.11.4
 pydantic_core==2.33.2
-PyPDF2==3.0.1
+pypdf==5.9.0
 pyparsing==3.2.3
 pytest==8.4.1
 pytest-asyncio==1.1.0

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -3,7 +3,7 @@
 import datetime
 
 import pytest
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 
 from diabetes.reporting import make_sugar_plot, generate_pdf_report
 


### PR DESCRIPTION
## Summary
- switch dependency from PyPDF2 to pypdf
- update tests to import PdfReader from pypdf

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_688f6a34cbb0832abef819440479e5ef