### PR TITLE
[reporting] Handle empty sugar data in plots

### DIFF
--- a/diabetes/reporting.py
+++ b/diabetes/reporting.py
@@ -44,9 +44,27 @@ _register_font('DejaVuSans-Bold', 'DejaVuSans-Bold.ttf')
 def make_sugar_plot(entries, period_label):
     """
     Генерирует график сахара за период. Возвращает BytesIO с PNG.
+    Если данных нет, возвращает изображение с сообщением об отсутствии данных.
     """
     times = [e.event_time for e in entries if e.sugar_before is not None]
     sugars_plot = [e.sugar_before for e in entries if e.sugar_before is not None]
+
+    if not sugars_plot:
+        buf = io.BytesIO()
+        plt.figure(figsize=(7, 3))
+        plt.text(
+            0.5,
+            0.5,
+            "Нет данных для построения графика",
+            ha="center",
+            va="center",
+        )
+        plt.axis("off")
+        plt.tight_layout()
+        plt.savefig(buf, format="png")
+        buf.seek(0)
+        plt.close()
+        return buf
 
     plt.figure(figsize=(7, 3))
     plt.plot(times, sugars_plot, marker='o', label='Сахар (ммоль/л)')

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -16,6 +16,7 @@ class DummyEntry:
         self.xe = xe
         self.dose = dose
 
+
 def test_make_sugar_plot():
     entries = [
         DummyEntry(
@@ -37,6 +38,23 @@ def test_make_sugar_plot():
     assert hasattr(buf, 'read')
     buf.seek(0)
     assert len(buf.read()) > 1000  # есть содержимое
+
+
+def test_make_sugar_plot_no_data():
+    entries = [
+        DummyEntry(
+            datetime.datetime(2025, 7, 1, 9, tzinfo=datetime.timezone.utc),
+            None,
+            40,
+            3.3,
+            6,
+        )
+    ]
+    buf = make_sugar_plot(entries, "тестовый период")
+    assert hasattr(buf, "read")
+    buf.seek(0)
+    assert len(buf.read()) > 1000
+
 
 def test_generate_pdf_report():
     entries = [


### PR DESCRIPTION
## Summary
- show placeholder message when there's no sugar data to plot
- test sugar plotting with missing values

## Testing
- `flake8 diabetes/ tests/test_reporting.py`
- `pytest tests/test_reporting.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f675cc148832a88becca6348b0768