### PR TITLE
[handlers] hook menu buttons for profile, report and history

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -130,10 +130,19 @@ def register_handlers(app: Application) -> None:
 
     # Import inside the function to avoid heavy imports at module import time
     # (for example OpenAI client initialization).
-    from . import dose_handlers, profile_handlers
+    from . import dose_handlers, profile_handlers, reporting_handlers
 
     app.add_handler(CommandHandler("profile", profile_handlers.profile_command))
     app.add_handler(CommandHandler("dose", dose_handlers.freeform_handler))
+    app.add_handler(
+        MessageHandler(filters.Regex("^📄 Мой профиль$"), profile_handlers.profile_view)
+    )
+    app.add_handler(
+        MessageHandler(filters.Regex("^📈 Отчёт$"), reporting_handlers.report_request)
+    )
+    app.add_handler(
+        MessageHandler(filters.Regex("^📊 История$"), reporting_handlers.history_view)
+    )
     app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, dose_handlers.freeform_handler)
     )

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -9,7 +9,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import diabetes.openai_utils as openai_utils  # noqa: F401
-    from diabetes import dose_handlers, profile_handlers
+    from diabetes import dose_handlers, profile_handlers, reporting_handlers
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     register_handlers(app)
@@ -22,6 +22,9 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert dose_handlers.photo_handler in callbacks
     assert dose_handlers.doc_handler in callbacks
     assert callback_router in callbacks
+    assert profile_handlers.profile_view in callbacks
+    assert reporting_handlers.report_request in callbacks
+    assert reporting_handlers.history_view in callbacks
 
     profile_cmd = [
         h for h in handlers if isinstance(h, CommandHandler) and h.callback is profile_handlers.profile_command
@@ -34,25 +37,50 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert dose_cmd and "dose" in dose_cmd[0].commands
 
     text_handlers = [
-        h for h in handlers
+        h
+        for h in handlers
         if isinstance(h, MessageHandler) and h.callback is dose_handlers.freeform_handler
     ]
     assert text_handlers
 
     photo_handlers = [
-        h for h in handlers
+        h
+        for h in handlers
         if isinstance(h, MessageHandler) and h.callback is dose_handlers.photo_handler
     ]
     assert photo_handlers
 
     doc_handlers = [
-        h for h in handlers
+        h
+        for h in handlers
         if isinstance(h, MessageHandler) and h.callback is dose_handlers.doc_handler
     ]
     assert doc_handlers
 
+    profile_view_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is profile_handlers.profile_view
+    ]
+    assert profile_view_handlers
+
+    report_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is reporting_handlers.report_request
+    ]
+    assert report_handlers
+
+    history_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is reporting_handlers.history_view
+    ]
+    assert history_handlers
+
     cb_handlers = [
-        h for h in handlers
+        h
+        for h in handlers
         if isinstance(h, CallbackQueryHandler) and h.callback is callback_router
     ]
     assert cb_handlers


### PR DESCRIPTION
## Summary
- wire menu buttons to proper handlers for profile view, report request, and history view
- add reporting utilities to request report date and display recent entries
- test registration of new menu handlers

## Testing
- `flake8 diabetes`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f77ea2d94832aae96810ecc3d8910