### PR TITLE
[handlers] Add report command and flag test

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -134,6 +134,7 @@ def register_handlers(app: Application) -> None:
 
     app.add_handler(CommandHandler("profile", profile_handlers.profile_command))
     app.add_handler(CommandHandler("dose", dose_handlers.freeform_handler))
+    app.add_handler(CommandHandler("report", reporting_handlers.report_request))
     app.add_handler(
         MessageHandler(filters.Regex("^📄 Мой профиль$"), profile_handlers.profile_view)
     )

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -1,0 +1,51 @@
+import os
+import datetime
+from types import SimpleNamespace
+
+import pytest
+
+
+class DummyMessage:
+    def __init__(self, text: str = ""):
+        self.text = text
+        self.texts: list[str] = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+@pytest.mark.asyncio
+async def test_report_request_flag_set_and_cleared(monkeypatch):
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+    import diabetes.openai_utils as openai_utils  # noqa: F401
+    import diabetes.reporting_handlers as reporting_handlers
+    import diabetes.dose_handlers as dose_handlers
+
+    message = DummyMessage()
+    update = SimpleNamespace(
+        message=message, effective_user=SimpleNamespace(id=1)
+    )
+    context = SimpleNamespace(user_data={})
+
+    await reporting_handlers.report_request(update, context)
+    assert context.user_data.get("awaiting_report_date") is True
+    assert any("YYYY-MM-DD" in t for t in message.texts)
+
+    called = {}
+
+    async def dummy_send_report(update, context, date_from, period_label, query=None):
+        called["called"] = True
+        expected = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+        assert date_from == expected
+
+    monkeypatch.setattr(dose_handlers, "send_report", dummy_send_report)
+
+    update2 = SimpleNamespace(
+        message=DummyMessage(text="2024-01-01"),
+        effective_user=SimpleNamespace(id=1),
+    )
+    await dose_handlers.freeform_handler(update2, context)
+
+    assert called.get("called")
+    assert "awaiting_report_date" not in context.user_data

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -71,6 +71,13 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     ]
     assert report_handlers
 
+    report_cmd = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is reporting_handlers.report_request
+    ]
+    assert report_cmd and "report" in report_cmd[0].commands
+
     history_handlers = [
         h
         for h in handlers


### PR DESCRIPTION
## Summary
- add /report command that prompts for report date
- test that awaiting_report_date flag is set and cleared when report is generated
- ensure register_handlers wires the new command

## Testing
- `flake8 diabetes/ tests/test_handlers_report_request.py tests/test_register_handlers.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7d041330832a8f0f833999fccdca