### PR TITLE
[functions] handle plus-minus ranges

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -86,6 +86,13 @@ def test_extract_nutrition_info_plus_minus_no_colon():
     assert carbs == 30
     assert xe == 2
 
+
+def test_extract_nutrition_info_plus_minus_with_comma():
+    text = "углеводы: 10,5 г ± 0,5 г, ХЕ: 2,5 ± 0,5"
+    carbs, xe = extract_nutrition_info(text)
+    assert carbs == pytest.approx(10.5)
+    assert xe == pytest.approx(2.5)
+
 def test_extract_nutrition_info_missing():
     text = "Нет данных"
     carbs, xe = extract_nutrition_info(text)


### PR DESCRIPTION
## Summary
- document `a ± b` parsing and return central value
- ignore error for `±` entries in `extract_nutrition_info`
- test `±` patterns with comma decimals

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_688f807cc5b4832aae5488ea5960a399