### PR TITLE
[handlers] handle unknown callback data

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -67,8 +67,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 return
         await query.edit_message_text("✅ Запись сохранена в дневник!")
         return
-
-    if data == "edit_entry":
+    elif data == "edit_entry":
         entry_data = context.user_data.get("pending_entry")
         if not entry_data:
             await query.edit_message_text("❗ Нет данных для редактирования.")
@@ -81,14 +80,12 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             parse_mode="Markdown",
         )
         return
-
-    if data == "cancel_entry":
+    elif data == "cancel_entry":
         context.user_data.pop("pending_entry", None)
         await query.edit_message_text("❌ Запись отменена.")
         await query.message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
         return
-
-    if ":" in data:
+    elif ":" in data:
         action, entry_id = data.split(":", 1)
         try:
             entry_id = int(entry_id)
@@ -117,6 +114,9 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 )
                 await query.edit_message_text("\n".join(text), parse_mode="Markdown")
                 return
+    else:
+        logger.warning("Unrecognized callback data: %s", data)
+        await query.edit_message_text("Команда не распознана")
 
 
 def register_handlers(app: Application) -> None:

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -65,3 +65,21 @@ async def test_callback_router_invalid_entry_id(caplog):
 
     assert query.edited == ["Некорректный идентификатор записи."]
     assert "Invalid entry_id in callback data" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_callback_router_unknown_data(caplog):
+    os.environ["OPENAI_API_KEY"] = "test"
+    os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
+    import diabetes.openai_utils  # noqa: F401
+    import diabetes.common_handlers as handlers
+
+    query = DummyQuery("foo")
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace(user_data={})
+
+    with caplog.at_level(logging.WARNING):
+        await handlers.callback_router(update, context)
+
+    assert query.edited == ["Команда не распознана"]
+    assert "Unrecognized callback data" in caplog.text


### PR DESCRIPTION
## Summary
- log and notify for unrecognized callback data
- test fallback response for unexpected callback queries

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_688f80fc5994832a9dd9b3016807ad8a