### PR TITLE
[style] Wrap long f-strings and argument lists

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -53,8 +53,10 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         context.user_data.pop("awaiting_report_date", None)
         return
 
-    if context.user_data.get("pending_entry") is not None and context.user_data.get("edit_id") is None:
-        entry = context.user_data["pending_entry"]
+    pending_entry = context.user_data.get("pending_entry")
+    edit_id = context.user_data.get("edit_id")
+    if pending_entry is not None and edit_id is None:
+        entry = pending_entry
         text = update.message.text.lower().strip()
         if re.fullmatch(r"-?\d+(?:[.,]\d+)?", text) and entry.get("sugar_before") is None:
             try:

--- a/diabetes/reporting.py
+++ b/diabetes/reporting.py
@@ -157,7 +157,14 @@ def generate_pdf_report(summary_lines, errors, day_lines, gpt_text, plot_buf):
             y -= 10 * mm
             plot_buf.seek(0)
             img_reader = ImageReader(plot_buf)
-            c.drawImage(img_reader, x_margin, y - 65*mm, width=160*mm, height=55*mm, preserveAspectRatio=True)
+            c.drawImage(
+                img_reader,
+                x_margin,
+                y - 65 * mm,
+                width=160 * mm,
+                height=55 * mm,
+                preserveAspectRatio=True,
+            )
             y -= 65 * mm
         except Exception as e:
             logging.exception("[PDF] Failed to draw plot image: %s", e)

--- a/diabetes/reporting_handlers.py
+++ b/diabetes/reporting_handlers.py
@@ -47,7 +47,13 @@ async def history_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await update.message.reply_text("\n".join(lines))
 
 
-async def send_report(update: Update, context: ContextTypes.DEFAULT_TYPE, date_from, period_label, query=None) -> None:
+async def send_report(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    date_from,
+    period_label,
+    query=None,
+) -> None:
     """Generate and send a PDF report for entries after ``date_from``."""
     user_id = update.effective_user.id
 
@@ -92,12 +98,26 @@ async def send_report(update: Update, context: ContextTypes.DEFAULT_TYPE, date_f
     pdf_buf.seek(0)
     if query:
         await query.edit_message_text(report_msg, parse_mode="HTML")
-        await query.message.reply_photo(plot_buf, caption="График сахара за период")
-        await query.message.reply_document(pdf_buf, filename="diabetes_report.pdf", caption="PDF-отчёт для врача")
+        await query.message.reply_photo(
+            plot_buf,
+            caption="График сахара за период",
+        )
+        await query.message.reply_document(
+            pdf_buf,
+            filename="diabetes_report.pdf",
+            caption="PDF-отчёт для врача",
+        )
     else:
         await update.message.reply_text(report_msg, parse_mode="HTML")
-        await update.message.reply_photo(plot_buf, caption="График сахара за период")
-        await update.message.reply_document(pdf_buf, filename="diabetes_report.pdf", caption="PDF-отчёт для врача")
+        await update.message.reply_photo(
+            plot_buf,
+            caption="График сахара за период",
+        )
+        await update.message.reply_document(
+            pdf_buf,
+            filename="diabetes_report.pdf",
+            caption="PDF-отчёт для врача",
+        )
 
 
 __all__ = ["send_report", "report_request", "history_view"]


### PR DESCRIPTION
## Summary
- Split long argument lists in report generation to improve readability
- Extract user data flags into variables to shorten conditional logic
- Break PDF plot rendering call into a multi-line statement

## Testing
- `flake8 diabetes`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_688f83a23418832aad6ea1796fea2292