### PR TITLE
[bot] Handle database init errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4,6 +4,7 @@ from diabetes.common_handlers import register_handlers
 from diabetes.db import init_db
 from diabetes.config import TELEGRAM_TOKEN
 from telegram.ext import ApplicationBuilder
+from sqlalchemy.exc import SQLAlchemyError
 import logging
 import sys
 
@@ -23,11 +24,16 @@ def main():
         )
         sys.exit(1)
 
-    init_db()
+    try:
+        init_db()
+    except SQLAlchemyError:
+        logger.exception("Failed to initialize the database")
+        sys.exit(1)
+
     app = ApplicationBuilder().token(TELEGRAM_TOKEN).build()
     register_handlers(app)
     app.run_polling()
 
+
 if __name__ == "__main__":
     main()
-

--- a/tests/test_bot_db_error.py
+++ b/tests/test_bot_db_error.py
@@ -1,0 +1,24 @@
+import logging
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+import bot
+
+
+def test_main_logs_db_error(monkeypatch, caplog):
+    monkeypatch.setattr(bot, "TELEGRAM_TOKEN", "token")
+
+    def faulty_init_db():
+        raise SQLAlchemyError("boom")
+
+    monkeypatch.setattr(bot, "init_db", faulty_init_db)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as exc:
+            bot.main()
+
+    assert exc.value.code == 1
+    assert any(
+        "Failed to initialize the database" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- log and exit on SQLAlchemyError during database initialization
- test bot startup logs database errors and exits

## Testing
- `flake8 bot.py tests/test_bot_db_error.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f8f923e80832a948c8af98797b449