### PR TITLE
[handlers] add prompts for photo, sugar, and dose

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -145,6 +145,15 @@ def register_handlers(app: Application) -> None:
         MessageHandler(filters.Regex("^📊 История$"), reporting_handlers.history_view)
     )
     app.add_handler(
+        MessageHandler(filters.Regex("^📷 Фото еды$"), dose_handlers.prompt_photo)
+    )
+    app.add_handler(
+        MessageHandler(filters.Regex("^❓ Мой сахар$"), dose_handlers.prompt_sugar)
+    )
+    app.add_handler(
+        MessageHandler(filters.Regex("^💉 Доза инсулина$"), dose_handlers.prompt_dose)
+    )
+    app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, dose_handlers.freeform_handler)
     )
     app.add_handler(MessageHandler(filters.PHOTO, dose_handlers.photo_handler))

--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -35,6 +35,36 @@ PHOTO_SUGAR = 7
 WAITING_GPT_FLAG = "waiting_gpt_response"
 
 
+async def prompt_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Prompt the user to send a meal photo for analysis."""
+
+    await update.message.reply_text(
+        "📷 Отправьте фото блюда — я помогу оценить углеводы и ХЕ.",
+        reply_markup=menu_keyboard,
+    )
+
+
+async def prompt_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Ask the user to enter current blood sugar level."""
+
+    await update.message.reply_text(
+        "Введите текущий уровень сахара (ммоль/л).",
+        reply_markup=menu_keyboard,
+    )
+
+
+async def prompt_dose(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Explain how to use the dose calculation."""
+
+    await update.message.reply_text(
+        "Укажите сахар, ХЕ или углеводы в сообщении, например:\n"
+        "`сахар=5.5 xe=1 carbs=60`\n"
+        "и я помогу рассчитать дозу.",
+        parse_mode="Markdown",
+        reply_markup=menu_keyboard,
+    )
+
+
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handle freeform text commands for adding diary entries."""
     raw_text = update.message.text.strip()
@@ -409,6 +439,9 @@ async def doc_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
 __all__ = [
     "PHOTO_SUGAR",
     "WAITING_GPT_FLAG",
+    "prompt_photo",
+    "prompt_sugar",
+    "prompt_dose",
     "freeform_handler",
     "photo_handler",
     "doc_handler",

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -1,0 +1,41 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+import diabetes.openai_utils as openai_utils  # noqa: F401
+from diabetes import dose_handlers
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+@pytest.mark.asyncio
+async def test_prompt_photo_sends_message():
+    message = DummyMessage()
+    update = SimpleNamespace(message=message)
+    await dose_handlers.prompt_photo(update, SimpleNamespace())
+    assert any("фото" in t.lower() for t in message.texts)
+
+
+@pytest.mark.asyncio
+async def test_prompt_sugar_sends_message():
+    message = DummyMessage()
+    update = SimpleNamespace(message=message)
+    await dose_handlers.prompt_sugar(update, SimpleNamespace())
+    assert any("сахар" in t.lower() for t in message.texts)
+
+
+@pytest.mark.asyncio
+async def test_prompt_dose_sends_message():
+    message = DummyMessage()
+    update = SimpleNamespace(message=message)
+    await dose_handlers.prompt_dose(update, SimpleNamespace())
+    assert any("доз" in t.lower() for t in message.texts)

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -21,6 +21,9 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert dose_handlers.freeform_handler in callbacks
     assert dose_handlers.photo_handler in callbacks
     assert dose_handlers.doc_handler in callbacks
+    assert dose_handlers.prompt_photo in callbacks
+    assert dose_handlers.prompt_sugar in callbacks
+    assert dose_handlers.prompt_dose in callbacks
     assert callback_router in callbacks
     assert profile_handlers.profile_view in callbacks
     assert reporting_handlers.report_request in callbacks
@@ -56,6 +59,27 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
         if isinstance(h, MessageHandler) and h.callback is dose_handlers.doc_handler
     ]
     assert doc_handlers
+
+    prompt_photo_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is dose_handlers.prompt_photo
+    ]
+    assert prompt_photo_handlers
+
+    prompt_sugar_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is dose_handlers.prompt_sugar
+    ]
+    assert prompt_sugar_handlers
+
+    prompt_dose_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is dose_handlers.prompt_dose
+    ]
+    assert prompt_dose_handlers
 
     profile_view_handlers = [
         h


### PR DESCRIPTION
## Summary
- add handlers for "📷 Фото еды", "❓ Мой сахар" and "💉 Доза инсулина"
- implement prompt functions giving user instructions
- test registration of new handlers and prompt messaging

## Testing
- `flake8 diabetes/`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f94aa9fe0832ab7509bc3ded4267e