### PR TITLE
[handlers] hook sugar and dose menu options

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -185,6 +185,15 @@ def register_handlers(app: Application) -> None:
         MessageHandler(filters.Regex("^📊 История$"), reporting_handlers.history_view)
     )
     app.add_handler(
+        MessageHandler(filters.Regex("^📷 Фото еды$"), dose_handlers.photo_prompt)
+    )
+    app.add_handler(
+        MessageHandler(filters.Regex("^❓ Мой сахар$"), dose_handlers.sugar_start)
+    )
+    app.add_handler(
+        MessageHandler(filters.Regex("^💉 Доза инсулина$"), dose_handlers.dose_start)
+    )
+    app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, dose_handlers.freeform_handler)
     )
     app.add_handler(MessageHandler(filters.PHOTO, dose_handlers.photo_handler))

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -70,6 +70,27 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     ]
     assert doc_handlers
 
+    photo_prompt_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is dose_handlers.photo_prompt
+    ]
+    assert photo_prompt_handlers
+
+    sugar_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is dose_handlers.sugar_start
+    ]
+    assert sugar_handlers
+
+    dose_start_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is dose_handlers.dose_start
+    ]
+    assert dose_start_handlers
+
     profile_view_handlers = [
         h
         for h in handlers


### PR DESCRIPTION
## Summary
- register photo, sugar and dose menu buttons
- implement photo_prompt, sugar_start and dose_start helpers
- cover handler registration for new menu flows

## Testing
- `flake8 diabetes`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f99e3fc04832a877d4b8fa693f1fe