### PR TITLE
[dose] add conversation handler for insulin dosing

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -173,8 +173,8 @@ def register_handlers(app: Application) -> None:
 
     app.add_handler(CommandHandler("start", start_command))
     app.add_handler(CommandHandler("profile", profile_handlers.profile_command))
-    app.add_handler(CommandHandler("dose", dose_handlers.freeform_handler))
     app.add_handler(CommandHandler("report", reporting_handlers.report_request))
+    app.add_handler(dose_handlers.dose_conv)
     app.add_handler(
         MessageHandler(filters.Regex("^📄 Мой профиль$"), profile_handlers.profile_view)
     )
@@ -185,15 +185,11 @@ def register_handlers(app: Application) -> None:
         MessageHandler(filters.Regex("^📊 История$"), reporting_handlers.history_view)
     )
     app.add_handler(
-
         MessageHandler(filters.Regex("^📷 Фото еды$"), dose_handlers.photo_prompt)
     )
     app.add_handler(
         MessageHandler(filters.Regex("^❓ Мой сахар$"), dose_handlers.sugar_start)
     )
-    app.add_handler(
-        MessageHandler(filters.Regex("^💉 Доза инсулина$"), dose_handlers.dose_start)
-
     app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, dose_handlers.freeform_handler)
     )

--- a/diabetes/ui.py
+++ b/diabetes/ui.py
@@ -30,10 +30,13 @@ menu_keyboard = ReplyKeyboardMarkup(
 )
 
 dose_keyboard = ReplyKeyboardMarkup(
-    keyboard=[[KeyboardButton("↩️ Назад")]],
+    keyboard=[
+        [KeyboardButton("ХЕ"), KeyboardButton("Углеводы")],
+        [KeyboardButton("↩️ Назад")],
+    ],
     resize_keyboard=True,
     one_time_keyboard=True,
-    input_field_placeholder="Введите значение или вернитесь назад…",
+    input_field_placeholder="Выберите метод расчёта…",
 )
 
 # ─────────────── Inline-клавиатуры (обрабатываются callback-ами) ───────────────

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -28,14 +28,16 @@ async def test_prompt_photo_sends_message():
 @pytest.mark.asyncio
 async def test_prompt_sugar_sends_message():
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    await dose_handlers.prompt_sugar(update, SimpleNamespace())
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+    await dose_handlers.prompt_sugar(update, context)
     assert any("сахар" in t.lower() for t in message.texts)
 
 
 @pytest.mark.asyncio
 async def test_prompt_dose_sends_message():
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    await dose_handlers.prompt_dose(update, SimpleNamespace())
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+    await dose_handlers.prompt_dose(update, context)
     assert any("доз" in t.lower() for t in message.texts)


### PR DESCRIPTION
## Summary
- introduce step-by-step insulin dose conversation with XE/carbs/sugar states
- register conversation handler and add method selection keyboard
- adjust tests for new conversation flow

## Testing
- `python -m flake8 diabetes/`
- `DB_HOST=localhost DB_PORT=5432 DB_NAME=test DB_USER=user DB_PASSWORD=pass pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f9cef8db8832a802993e8b3ca5172