### PR TITLE
[handlers] add sugar recording conversation

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -175,6 +175,8 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("profile", profile_handlers.profile_command))
     app.add_handler(CommandHandler("report", reporting_handlers.report_request))
     app.add_handler(dose_handlers.dose_conv)
+    app.add_handler(dose_handlers.sugar_conv)
+    app.add_handler(CommandHandler("sugar", dose_handlers.sugar_start))
     app.add_handler(
         MessageHandler(filters.Regex("^📄 Мой профиль$"), profile_handlers.profile_view)
     )
@@ -186,9 +188,6 @@ def register_handlers(app: Application) -> None:
     )
     app.add_handler(
         MessageHandler(filters.Regex("^📷 Фото еды$"), dose_handlers.photo_prompt)
-    )
-    app.add_handler(
-        MessageHandler(filters.Regex("^❓ Мой сахар$"), dose_handlers.sugar_start)
     )
     app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, dose_handlers.freeform_handler)

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -49,12 +49,19 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
 
     conv_handlers = [h for h in handlers if isinstance(h, ConversationHandler)]
     assert dose_handlers.dose_conv in conv_handlers
+    assert dose_handlers.sugar_conv in conv_handlers
     conv_cmds = [
         ep
         for ep in dose_handlers.dose_conv.entry_points
         if isinstance(ep, CommandHandler)
     ]
     assert conv_cmds and "dose" in conv_cmds[0].commands
+    sugar_conv_cmds = [
+        ep
+        for ep in dose_handlers.sugar_conv.entry_points
+        if isinstance(ep, CommandHandler)
+    ]
+    assert sugar_conv_cmds and "sugar" in sugar_conv_cmds[0].commands
 
     text_handlers = [
         h
@@ -85,12 +92,12 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     ]
     assert photo_prompt_handlers
 
-    sugar_handlers = [
+    sugar_cmd = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is dose_handlers.sugar_start
+        if isinstance(h, CommandHandler) and h.callback is dose_handlers.sugar_start
     ]
-    assert sugar_handlers
+    assert sugar_cmd and "sugar" in sugar_cmd[0].commands
 
     profile_view_handlers = [
         h


### PR DESCRIPTION
## Summary
- handle `/sugar` via a new conversation that records the user's blood sugar
- save sugar readings to the diary through `commit_session`
- wire the "❓ Мой сахар" button and `/sugar` command to the same flow

## Testing
- `flake8 diabetes`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa09d9a84832a9ac78bc20d76dba7