### PR TITLE
[reporting] Add report period keyboard

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -196,6 +196,11 @@ def register_handlers(app: Application) -> None:
     app.add_handler(
         MessageHandler(filters.Document.IMAGE, dose_handlers.doc_handler)
     )
+    app.add_handler(
+        CallbackQueryHandler(
+            reporting_handlers.report_period_callback, pattern="^report_period:"
+        )
+    )
     app.add_handler(CallbackQueryHandler(callback_router))
 
 

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -8,14 +8,26 @@ import pytest
 class DummyMessage:
     def __init__(self, text: str = ""):
         self.text = text
-        self.texts: list[str] = []
+        self.replies: list[tuple[str, dict]] = []
 
     async def reply_text(self, text, **kwargs):
-        self.texts.append(text)
+        self.replies.append((text, kwargs))
+
+
+class DummyQuery:
+    def __init__(self, data: str):
+        self.data = data
+        self.edited: list[str] = []
+
+    async def answer(self):
+        pass
+
+    async def edit_message_text(self, text, **kwargs):
+        self.edited.append(text)
 
 
 @pytest.mark.asyncio
-async def test_report_request_flag_set_and_cleared(monkeypatch):
+async def test_report_request_and_custom_flow(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import diabetes.openai_utils as openai_utils  # noqa: F401
@@ -29,8 +41,19 @@ async def test_report_request_flag_set_and_cleared(monkeypatch):
     context = SimpleNamespace(user_data={})
 
     await reporting_handlers.report_request(update, context)
+    assert "awaiting_report_date" not in context.user_data
+    assert any("Выберите период" in t[0] for t in message.replies)
+    assert message.replies[0][1].get("reply_markup") is not None
+
+    query = DummyQuery("report_period:custom")
+    update_cb = SimpleNamespace(
+        callback_query=query, effective_user=SimpleNamespace(id=1)
+    )
+
+    await reporting_handlers.report_period_callback(update_cb, context)
+
     assert context.user_data.get("awaiting_report_date") is True
-    assert any("YYYY-MM-DD" in t for t in message.texts)
+    assert any("YYYY-MM-DD" in text for text in query.edited)
 
     called = {}
 
@@ -49,3 +72,42 @@ async def test_report_request_flag_set_and_cleared(monkeypatch):
 
     assert called.get("called")
     assert "awaiting_report_date" not in context.user_data
+
+
+@pytest.mark.asyncio
+async def test_report_period_callback_week(monkeypatch):
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+    import diabetes.openai_utils as openai_utils  # noqa: F401
+    import diabetes.reporting_handlers as reporting_handlers
+
+    called: dict[str, datetime.datetime | str] = {}
+
+    async def dummy_send_report(update, context, date_from, period_label, query=None):
+        called["date_from"] = date_from
+        called["period_label"] = period_label
+
+    monkeypatch.setattr(reporting_handlers, "send_report", dummy_send_report)
+
+    fixed_now = datetime.datetime(2024, 1, 10, tzinfo=datetime.timezone.utc)
+
+    class DummyDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(reporting_handlers.datetime, "datetime", DummyDateTime)
+
+    query = DummyQuery("report_period:week")
+    update_cb = SimpleNamespace(
+        callback_query=query, effective_user=SimpleNamespace(id=1)
+    )
+    context = SimpleNamespace(user_data={})
+
+    await reporting_handlers.report_period_callback(update_cb, context)
+
+    expected = (fixed_now - datetime.timedelta(days=7)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    assert called["date_from"] == expected
+    assert called["period_label"] == "последнюю неделю"

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -31,6 +31,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert dose_handlers.prompt_photo in callbacks
     assert dose_handlers.prompt_sugar in callbacks
     assert callback_router in callbacks
+    assert reporting_handlers.report_period_callback in callbacks
     assert profile_handlers.profile_view in callbacks
     assert reporting_handlers.report_request in callbacks
     assert reporting_handlers.history_view in callbacks
@@ -133,3 +134,10 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
         if isinstance(h, CallbackQueryHandler) and h.callback is callback_router
     ]
     assert cb_handlers
+    report_cb_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, CallbackQueryHandler)
+        and h.callback is reporting_handlers.report_period_callback
+    ]
+    assert report_cb_handlers


### PR DESCRIPTION
## Summary
- add inline keyboard to choose report period
- handle report period selection with dedicated callback
- register callback handler and add tests for custom date flow

## Testing
- `flake8 diabetes/`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fa70b3ed8832a96b4ac93d059a497