### PR TITLE
[handlers] add history command handler

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -174,6 +174,7 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("start", start_command))
     app.add_handler(CommandHandler("profile", profile_handlers.profile_command))
     app.add_handler(CommandHandler("report", reporting_handlers.report_request))
+    app.add_handler(CommandHandler("history", reporting_handlers.history_view))
     app.add_handler(dose_handlers.dose_conv)
     app.add_handler(dose_handlers.sugar_conv)
     app.add_handler(CommandHandler("sugar", dose_handlers.sugar_start))

--- a/tests/test_handlers_history_view.py
+++ b/tests/test_handlers_history_view.py
@@ -1,0 +1,61 @@
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from diabetes.db import Base, Entry
+import diabetes.reporting_handlers as handlers
+
+
+class DummyMessage:
+    def __init__(self, text: str = ""):
+        self.text = text
+        self.replies: list[str] = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trigger_text", ["/history", "📊 История"])
+async def test_history_view_lists_entries(monkeypatch, trigger_text):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(handlers, "SessionLocal", TestSession)
+
+    now = datetime.datetime(2024, 1, 2, 12, tzinfo=datetime.timezone.utc)
+    with TestSession() as session:
+        session.add(
+            Entry(
+                telegram_id=1,
+                event_time=now,
+                sugar_before=5.6,
+                carbs_g=30,
+                xe=2.5,
+                dose=1,
+            )
+        )
+        session.add(
+            Entry(
+                telegram_id=1,
+                event_time=now - datetime.timedelta(days=1),
+                sugar_before=6.1,
+                carbs_g=40,
+                xe=3.3,
+                dose=2,
+            )
+        )
+        session.commit()
+
+    message = DummyMessage(trigger_text)
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+
+    await handlers.history_view(update, context)
+
+    assert message.replies
+    assert "Последние записи" in message.replies[0]
+    assert "сахар" in message.replies[0]

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -85,7 +85,6 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     ]
     assert doc_handlers
 
-
     photo_prompt_handlers = [
         h
         for h in handlers
@@ -127,6 +126,13 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
         if isinstance(h, MessageHandler) and h.callback is reporting_handlers.history_view
     ]
     assert history_handlers
+
+    history_cmd = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is reporting_handlers.history_view
+    ]
+    assert history_cmd and "history" in history_cmd[0].commands
 
     cb_handlers = [
         h


### PR DESCRIPTION
## Summary
- add /history command handler in common_handlers.register_handlers
- test history_view via command and button

## Testing
- `flake8 diabetes tests/test_register_handlers.py tests/test_handlers_history_view.py`
- `OPENAI_API_KEY=test OPENAI_ASSISTANT_ID=asst_test DB_USER=u DB_PASSWORD=p DB_HOST=h DB_PORT=1 DB_NAME=n pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_688fab65d334832a81938e3f307ec0b2