### PR TITLE
[tests] Reorder os import

### DIFF
--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -1,5 +1,5 @@
-import os
 from types import SimpleNamespace
+import os
 
 import pytest
 


### PR DESCRIPTION
## Summary
- Ensure `os` is imported after `SimpleNamespace` in `test_handlers_prompts.py`

## Testing
- `flake8 diabetes/`
- `pytest tests/test_handlers_prompts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fb269dbec832a9d7b312089e1ee20