### PR TITLE
[gpt_command_parser] Group imports

### DIFF
--- a/diabetes/gpt_command_parser.py
+++ b/diabetes/gpt_command_parser.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import re
+
 from openai import OpenAIError
 
 from diabetes.gpt_client import _get_client


### PR DESCRIPTION
## Summary
- Separate standard library and third-party imports in `gpt_command_parser`

## Testing
- `python -m flake8 diabetes/`
- `python -m pytest tests/` *(fails: DB_PASSWORD environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_688fba7a7208832a8f678f988df38fbb