### PR TITLE
[reporting] Organize imports

### DIFF
--- a/diabetes/reporting.py
+++ b/diabetes/reporting.py
@@ -2,15 +2,17 @@
 
 import io
 import logging
-import matplotlib.pyplot as plt
 import os
+import textwrap
+
+import matplotlib.pyplot as plt
 from reportlab.lib.pagesizes import A4
-from reportlab.pdfgen import canvas
 from reportlab.lib.units import mm
 from reportlab.lib.utils import ImageReader
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
-import textwrap
+from reportlab.pdfgen import canvas
+
 from diabetes.config import FONT_DIR
 
 # Регистрация шрифтов для поддержки кириллицы и жирного начертания


### PR DESCRIPTION
## Summary
- tidy import order in reporting module, ensuring required stdlib and third-party modules are imported

## Testing
- `flake8 diabetes/`
- `pytest tests/` *(fails: DB_PASSWORD environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_688fbc9c0880832a857ebfa2e776240f