### PR TITLE
[ui] add sugar back keyboard

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -23,7 +23,7 @@ from diabetes.db import SessionLocal, User, Entry, Profile
 from diabetes.functions import extract_nutrition_info, calc_bolus, PatientProfile
 from diabetes.gpt_client import create_thread, send_message, _get_client
 from diabetes.gpt_command_parser import parse_command
-from diabetes.ui import menu_keyboard, confirm_keyboard, dose_keyboard
+from diabetes.ui import menu_keyboard, confirm_keyboard, dose_keyboard, sugar_keyboard
 from .common_handlers import commit_session
 from .reporting_handlers import send_report
 
@@ -58,7 +58,7 @@ async def sugar_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
         "event_time": datetime.datetime.now(datetime.timezone.utc),
     }
     await update.message.reply_text(
-        "Введите текущий уровень сахара (ммоль/л).", reply_markup=menu_keyboard
+        "Введите текущий уровень сахара (ммоль/л).", reply_markup=sugar_keyboard
     )
     return SUGAR_VAL
 

--- a/diabetes/ui.py
+++ b/diabetes/ui.py
@@ -14,7 +14,7 @@ from telegram import (
     KeyboardButton,
 )
 
-__all__ = ("menu_keyboard", "dose_keyboard", "confirm_keyboard")
+__all__ = ("menu_keyboard", "dose_keyboard", "sugar_keyboard", "confirm_keyboard")
 
 # ─────────────── Reply-клавиатуры (отображаются на экране чата) ───────────────
 
@@ -37,6 +37,13 @@ dose_keyboard = ReplyKeyboardMarkup(
     resize_keyboard=True,
     one_time_keyboard=True,
     input_field_placeholder="Выберите метод расчёта…",
+)
+
+sugar_keyboard = ReplyKeyboardMarkup(
+    keyboard=[[KeyboardButton("↩️ Назад")]],
+    resize_keyboard=True,
+    one_time_keyboard=True,
+    input_field_placeholder="Введите уровень сахара…",
 )
 
 # ─────────────── Inline-клавиатуры (обрабатываются callback-ами) ───────────────

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -7,14 +7,17 @@ os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import diabetes.openai_utils as openai_utils  # noqa: F401
 from diabetes import dose_handlers
+from diabetes.ui import sugar_keyboard
 
 
 class DummyMessage:
     def __init__(self):
-        self.texts = []
+        self.texts: list[str] = []
+        self.kwargs: list[dict] = []
 
     async def reply_text(self, text, **kwargs):
         self.texts.append(text)
+        self.kwargs.append(kwargs)
 
 
 @pytest.mark.asyncio
@@ -32,6 +35,7 @@ async def test_prompt_sugar_sends_message():
     context = SimpleNamespace(user_data={})
     await dose_handlers.prompt_sugar(update, context)
     assert any("сахар" in t.lower() for t in message.texts)
+    assert message.kwargs and message.kwargs[0].get("reply_markup") is sugar_keyboard
 
 
 @pytest.mark.asyncio
@@ -41,3 +45,4 @@ async def test_prompt_dose_sends_message():
     context = SimpleNamespace(user_data={})
     await dose_handlers.prompt_dose(update, context)
     assert any("доз" in t.lower() for t in message.texts)
+

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+import os
+
+import pytest
+from telegram.ext import ConversationHandler, MessageHandler
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+import diabetes.openai_utils as openai_utils  # noqa: F401
+from diabetes import dose_handlers
+
+
+class DummyMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.replies: list[str] = []
+        self.kwargs: list[dict] = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_sugar_val_back_cancels():
+    message = DummyMessage("↩️ Назад")
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}})
+    result = await dose_handlers.sugar_val(update, context)
+    assert result == ConversationHandler.END
+    assert message.replies and message.replies[-1] == "Отменено."
+    assert context.user_data == {}
+
+
+def test_sugar_conv_has_back_fallback():
+    fallbacks = dose_handlers.sugar_conv.fallbacks
+    assert any(
+        isinstance(h, MessageHandler)
+        and h.callback is dose_handlers.dose_cancel
+        and getattr(getattr(h, "filters", None), "pattern", None).pattern == "^↩️ Назад$"
+        for h in fallbacks
+    )
+


### PR DESCRIPTION
## Summary
- add `sugar_keyboard` reply keyboard for sugar entry
- use `sugar_keyboard` in `sugar_start`
- test sugar flow cancellation

## Testing
- `python -m flake8 diabetes/`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_68901e6e69c8832aadd609c64abc2be0