### PR TITLE
[ui] Rename sugar button

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -179,7 +179,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "/help - справка\n\n"
         "📲 Кнопки меню:\n"
         "📷 Фото еды\n"
-        "❓ Мой сахар\n"
+        "🩸 Уровень сахара\n"
         "💉 Доза инсулина\n"
         "📊 История\n"
         "📈 Отчёт\n"

--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -611,7 +611,7 @@ prompt_dose = dose_start
 sugar_conv = ConversationHandler(
     entry_points=[
         CommandHandler("sugar", sugar_start),
-        MessageHandler(filters.Regex("^❓ Мой сахар$"), sugar_start),
+        MessageHandler(filters.Regex("^🩸 Уровень сахара$"), sugar_start),
     ],
     states={
         SUGAR_VAL: [MessageHandler(filters.TEXT & ~filters.COMMAND, sugar_val)],
@@ -633,7 +633,7 @@ dose_conv = ConversationHandler(
     fallbacks=[
         MessageHandler(filters.Regex("^↩️ Назад$"), dose_cancel),
         MessageHandler(filters.Regex("^📷 Фото еды$"), _cancel_then(photo_prompt)),
-        MessageHandler(filters.Regex("^❓ Мой сахар$"), _cancel_then(sugar_start)),
+        MessageHandler(filters.Regex("^🩸 Уровень сахара$"), _cancel_then(sugar_start)),
         MessageHandler(filters.Regex("^📊 История$"), _cancel_then(history_view)),
         MessageHandler(filters.Regex("^📈 Отчёт$"), _cancel_then(report_request)),
         MessageHandler(filters.Regex("^📄 Мой профиль$"), _cancel_then(profile_view)),

--- a/diabetes/ui.py
+++ b/diabetes/ui.py
@@ -20,7 +20,7 @@ __all__ = ("menu_keyboard", "dose_keyboard", "sugar_keyboard", "confirm_keyboard
 
 menu_keyboard = ReplyKeyboardMarkup(
     keyboard=[
-        [KeyboardButton("📷 Фото еды"), KeyboardButton("❓ Мой сахар")],
+        [KeyboardButton("📷 Фото еды"), KeyboardButton("🩸 Уровень сахара")],
         [KeyboardButton("💉 Доза инсулина"), KeyboardButton("📊 История")],
         [KeyboardButton("📈 Отчёт"), KeyboardButton("📄 Мой профиль")],
         [KeyboardButton("ℹ️ Помощь")],


### PR DESCRIPTION
## Summary
- Clarify sugar level button text to "🩸 Уровень сахара" in main menu and help
- Update dose handlers to listen for the new button label

## Testing
- `flake8 diabetes/`
- `pytest tests/` *(fails: DB_PASSWORD environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68902fa31a1c832a8963fd24857acc8b