### PR TITLE
[handlers] Add profile edit flow and back navigation

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -208,6 +208,7 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("report", reporting_handlers.report_request))
     app.add_handler(dose_handlers.dose_conv)
     app.add_handler(dose_handlers.sugar_conv)
+    app.add_handler(profile_handlers.profile_conv)
     app.add_handler(CommandHandler("sugar", dose_handlers.sugar_start))
     app.add_handler(CommandHandler("cancel", dose_handlers.dose_cancel))
     app.add_handler(CommandHandler("help", help_command))
@@ -242,6 +243,9 @@ def register_handlers(app: Application) -> None:
         CallbackQueryHandler(
             reporting_handlers.report_period_callback, pattern="^report_period:"
         )
+    )
+    app.add_handler(
+        CallbackQueryHandler(profile_handlers.profile_back, pattern="^profile_back$")
     )
     app.add_handler(CallbackQueryHandler(callback_router))
 

--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
-from telegram import Update
-from telegram.ext import ContextTypes, ConversationHandler
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import (
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+    ConversationHandler,
+    MessageHandler,
+    filters,
+)
 
 from diabetes.db import SessionLocal, Profile
 from diabetes.ui import menu_keyboard
 from .common_handlers import commit_session
+
+
+PROFILE_ICR, PROFILE_CF, PROFILE_TARGET = range(3)
 
 
 async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -95,7 +105,13 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         f"• КЧ: {profile.cf} ммоль/л\n"
         f"• Целевой сахар: {profile.target_bg} ммоль/л"
     )
-    await update.message.reply_text(msg)
+    keyboard = InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("✏️ Изменить", callback_data="profile_edit")],
+            [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
+        ]
+    )
+    await update.message.reply_text(msg, reply_markup=keyboard)
 
 
 async def profile_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -104,8 +120,107 @@ async def profile_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     return ConversationHandler.END
 
 
+async def profile_back(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Return to main menu from profile view."""
+    query = update.callback_query
+    await query.answer()
+    await query.message.delete()
+    await query.message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
+
+
+async def profile_edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Start step-by-step profile setup."""
+    query = update.callback_query
+    await query.answer()
+    await query.message.edit_text("Введите коэффициент ИКХ (г/ед.):")
+    return PROFILE_ICR
+
+
+async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Handle ICR input."""
+    text = update.message.text.strip().replace(",", ".")
+    try:
+        icr = float(text)
+    except ValueError:
+        await update.message.reply_text("Введите ИКХ числом.")
+        return PROFILE_ICR
+    if icr <= 0:
+        await update.message.reply_text("ИКХ должен быть больше 0.")
+        return PROFILE_ICR
+    context.user_data["profile_icr"] = icr
+    await update.message.reply_text("Введите коэффициент чувствительности (КЧ) ммоль/л.")
+    return PROFILE_CF
+
+
+async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Handle CF input."""
+    text = update.message.text.strip().replace(",", ".")
+    try:
+        cf = float(text)
+    except ValueError:
+        await update.message.reply_text("Введите КЧ числом.")
+        return PROFILE_CF
+    if cf <= 0:
+        await update.message.reply_text("КЧ должен быть больше 0.")
+        return PROFILE_CF
+    context.user_data["profile_cf"] = cf
+    await update.message.reply_text("Введите целевой уровень сахара (ммоль/л).")
+    return PROFILE_TARGET
+
+
+async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Handle target BG input and save profile."""
+    text = update.message.text.strip().replace(",", ".")
+    try:
+        target = float(text)
+    except ValueError:
+        await update.message.reply_text("Введите целевой сахар числом.")
+        return PROFILE_TARGET
+    if target <= 0:
+        await update.message.reply_text("Целевой сахар должен быть больше 0.")
+        return PROFILE_TARGET
+    icr = context.user_data.pop("profile_icr")
+    cf = context.user_data.pop("profile_cf")
+    user_id = update.effective_user.id
+    with SessionLocal() as session:
+        prof = session.get(Profile, user_id)
+        if not prof:
+            prof = Profile(telegram_id=user_id)
+            session.add(prof)
+        prof.icr = icr
+        prof.cf = cf
+        prof.target_bg = target
+        if not commit_session(session):
+            await update.message.reply_text("⚠️ Не удалось сохранить профиль.")
+            return ConversationHandler.END
+    await update.message.reply_text(
+        "✅ Профиль обновлён:\n"
+        f"• ИКХ: {icr} г/ед.\n"
+        f"• КЧ: {cf} ммоль/л\n"
+        f"• Целевой сахар: {target} ммоль/л",
+        reply_markup=menu_keyboard,
+    )
+    return ConversationHandler.END
+
+
+profile_conv = ConversationHandler(
+    entry_points=[CallbackQueryHandler(profile_edit, pattern="^profile_edit$")],
+    states={
+        PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_icr)],
+        PROFILE_CF: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_cf)],
+        PROFILE_TARGET: [
+            MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)
+        ],
+    },
+    fallbacks=[CommandHandler("cancel", profile_cancel)],
+)
+
+
 __all__ = [
     "profile_command",
     "profile_view",
     "profile_cancel",
+    "profile_back",
+    "profile_edit",
+    "profile_conv",
 ]

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from unittest.mock import MagicMock
+from telegram import InlineKeyboardMarkup
 
 from diabetes.db import Base, User, Profile
 
@@ -10,9 +11,14 @@ from diabetes.db import Base, User, Profile
 class DummyMessage:
     def __init__(self):
         self.texts = []
+        self.markups = []
 
     async def reply_text(self, text, **kwargs):
         self.texts.append(text)
+        self.markups.append(kwargs.get("reply_markup"))
+
+    async def delete(self):
+        pass
 
 
 @pytest.mark.parametrize(
@@ -57,6 +63,12 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
     assert f"• ИКХ: {expected_icr} г/ед." in message2.texts[0]
     assert f"• КЧ: {expected_cf} ммоль/л" in message2.texts[0]
     assert f"• Целевой сахар: {expected_target} ммоль/л" in message2.texts[0]
+    markup = message2.markups[0]
+    assert isinstance(markup, InlineKeyboardMarkup)
+    buttons = [b for row in markup.inline_keyboard for b in row]
+    callbacks = {b.text: b.callback_data for b in buttons}
+    assert callbacks["✏️ Изменить"] == "profile_edit"
+    assert callbacks["🔙 Назад"] == "profile_back"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -34,6 +34,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert callback_router in callbacks
     assert reporting_handlers.report_period_callback in callbacks
     assert profile_handlers.profile_view in callbacks
+    assert profile_handlers.profile_back in callbacks
     assert reporting_handlers.report_request in callbacks
     assert reporting_handlers.history_view in callbacks
 
@@ -52,6 +53,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     conv_handlers = [h for h in handlers if isinstance(h, ConversationHandler)]
     assert dose_handlers.dose_conv in conv_handlers
     assert dose_handlers.sugar_conv in conv_handlers
+    assert profile_handlers.profile_conv in conv_handlers
     conv_cmds = [
         ep
         for ep in dose_handlers.dose_conv.entry_points
@@ -64,6 +66,13 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
         if isinstance(ep, CommandHandler)
     ]
     assert sugar_conv_cmds and "sugar" in sugar_conv_cmds[0].commands
+    profile_conv_cb = [
+        ep
+        for ep in profile_handlers.profile_conv.entry_points
+        if isinstance(ep, CallbackQueryHandler)
+        and ep.callback is profile_handlers.profile_edit
+    ]
+    assert profile_conv_cb
 
     text_handlers = [
         h
@@ -149,3 +158,10 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
         and h.callback is reporting_handlers.report_period_callback
     ]
     assert report_cb_handlers
+    profile_back_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, CallbackQueryHandler)
+        and h.callback is profile_handlers.profile_back
+    ]
+    assert profile_back_handlers


### PR DESCRIPTION
## Summary
- show inline edit/back buttons in profile view
- add step-by-step profile editing conversation and back handler
- register profile callbacks in common handler

## Testing
- `flake8 diabetes/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890318a7300832a8460eb7057c6b03d