### PR TITLE
[handlers] add menu command fallback to dose conversations

### DIFF
--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+import os
+
+import pytest
+from telegram.ext import CommandHandler
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+import diabetes.openai_utils as openai_utils  # noqa: F401
+from diabetes import dose_handlers
+
+
+class DummyMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.replies: list[str] = []
+        self.kwargs: list[dict] = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
+
+
+def _get_menu_handler(fallbacks):
+    return next(
+        h
+        for h in fallbacks
+        if isinstance(h, CommandHandler) and "menu" in getattr(h, "commands", [])
+    )
+
+
+@pytest.mark.asyncio
+async def test_sugar_conv_menu_then_photo():
+    handler = _get_menu_handler(dose_handlers.sugar_conv.fallbacks)
+    message = DummyMessage("/menu")
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}})
+
+    await handler.callback(update, context)
+
+    assert message.replies[0] == "Отменено."
+    assert any("выберите" in r.lower() for r in message.replies[1:])
+    assert context.user_data == {}
+
+    next_message = DummyMessage("📷 Фото еды")
+    next_update = SimpleNamespace(
+        message=next_message, effective_user=SimpleNamespace(id=1)
+    )
+    await dose_handlers.photo_prompt(next_update, context)
+    assert any("фото" in r.lower() for r in next_message.replies)
+
+@pytest.mark.asyncio
+async def test_dose_conv_menu_then_photo():
+    handler = _get_menu_handler(dose_handlers.dose_conv.fallbacks)
+    message = DummyMessage("/menu")
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}})
+
+    await handler.callback(update, context)
+
+    assert message.replies[0] == "Отменено."
+    assert any("выберите" in r.lower() for r in message.replies[1:])
+    assert context.user_data == {}
+
+    next_message = DummyMessage("📷 Фото еды")
+    next_update = SimpleNamespace(
+        message=next_message, effective_user=SimpleNamespace(id=1)
+    )
+    await dose_handlers.photo_prompt(next_update, context)
+    assert any("фото" in r.lower() for r in next_message.replies)
+

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -22,11 +22,18 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_sugar_val_back_cancels():
+async def test_sugar_back_fallback_cancels():
+    handler = next(
+        h
+        for h in dose_handlers.sugar_conv.fallbacks
+        if isinstance(h, MessageHandler)
+        and getattr(getattr(h, "filters", None), "pattern", None).pattern
+        == "^↩️ Назад$"
+    )
     message = DummyMessage("↩️ Назад")
     update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     context = SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}})
-    result = await dose_handlers.sugar_val(update, context)
+    result = await handler.callback(update, context)
     assert result == ConversationHandler.END
     assert message.replies and message.replies[-1] == "Отменено."
     assert context.user_data == {}
@@ -51,4 +58,3 @@ def test_sugar_conv_has_back_fallback():
         and getattr(getattr(h, "filters", None), "pattern", None).pattern == "^↩️ Назад$"
         for h in fallbacks
     )
-


### PR DESCRIPTION
## Summary
- route non-numeric input to fallbacks and support /menu in sugar and dose conversations
- drop manual back-arrow checks in dose input handlers
- test menu fallback behaviour and sugar back fallbacks

## Testing
- `python -m flake8 diabetes/`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_68903dd6b808832a884d411fb33d9457