### PR TITLE
[handlers] show profile hint on start

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 
-from telegram import Update
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import (
     Application,
     CallbackQueryHandler,
@@ -19,7 +19,7 @@ from telegram.ext import (
 )
 from sqlalchemy.exc import SQLAlchemyError
 
-from diabetes.db import SessionLocal, Entry, User
+from diabetes.db import Entry, Profile, SessionLocal, User
 from diabetes.ui import menu_keyboard
 
 logger = logging.getLogger(__name__)
@@ -156,6 +156,27 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     await update.message.reply_text(
         f"{greeting}\n\n📋 Выберите действие:", reply_markup=menu_keyboard
     )
+
+    with SessionLocal() as session:
+        profile = session.get(Profile, user_id)
+
+    if (
+        not profile
+        or profile.icr is None
+        or profile.cf is None
+        or profile.target_bg is None
+    ) and not context.user_data.get("profile_hint_sent"):
+        context.user_data["profile_hint_sent"] = True
+        keyboard = InlineKeyboardMarkup(
+            [
+                [InlineKeyboardButton("✏️ Заполнить профиль", callback_data="profile_edit")]
+            ]
+        )
+        await update.message.reply_text(
+            "Чтобы бот мог рассчитывать дозу, заполните профиль:\n"
+            "/profile <ИКХ> <КЧ> <целевой>",
+            reply_markup=keyboard,
+        )
 
 
 async def menu_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_start_command.py
+++ b/tests/test_start_command.py
@@ -1,12 +1,13 @@
 import os
+os.environ.setdefault("DB_PASSWORD", "test")
 from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from diabetes.db import Base, User
 import diabetes.common_handlers as handlers
+from diabetes.db import Base, Profile, User
 
 
 class DummyMessage:
@@ -20,10 +21,11 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_start_command_creates_user_and_shows_menu(monkeypatch):
+async def test_start_command_shows_profile_hint_only_once(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import diabetes.gpt_client as gpt_client
+
     monkeypatch.setattr(gpt_client, "create_thread", lambda: "tid")
 
     engine = create_engine("sqlite:///:memory:")
@@ -33,16 +35,55 @@ async def test_start_command_creates_user_and_shows_menu(monkeypatch):
     monkeypatch.setattr(handlers, "menu_keyboard", "MK")
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1, first_name="Ann"))
+    update = SimpleNamespace(
+        message=message, effective_user=SimpleNamespace(id=1, first_name="Ann")
+    )
     context = SimpleNamespace(user_data={})
 
     await handlers.start_command(update, context)
 
+    # User created and greeting + hint sent
     with TestSession() as session:
         user = session.get(User, 1)
         assert user is not None
-        assert user.thread_id == "tid"
+    assert len(message.texts) == 2
+    assert message.kwargs[0]["reply_markup"] == "MK"
+    assert "/profile" in message.texts[1]
 
-    assert context.user_data["thread_id"] == "tid"
-    assert any("Выберите" in t for t in message.texts)
+    # Second call should not repeat the hint
+    await handlers.start_command(update, context)
+    assert len(message.texts) == 3
+    assert sum("/profile" in t for t in message.texts) == 1
+
+
+@pytest.mark.asyncio
+async def test_start_command_without_hint_when_profile_complete(monkeypatch):
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+    import diabetes.gpt_client as gpt_client
+
+    monkeypatch.setattr(gpt_client, "create_thread", lambda: "tid")
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(handlers, "SessionLocal", TestSession)
+    monkeypatch.setattr(handlers, "menu_keyboard", "MK")
+
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="tid"))
+        session.add(Profile(telegram_id=1, icr=10, cf=2, target_bg=5))
+        session.commit()
+
+    message = DummyMessage()
+    update = SimpleNamespace(
+        message=message, effective_user=SimpleNamespace(id=1, first_name="Ann")
+    )
+    context = SimpleNamespace(user_data={"thread_id": "tid"})
+
+    await handlers.start_command(update, context)
+
+    # Only greeting should be sent
+    assert len(message.texts) == 1
+    assert "/profile" not in message.texts[0]
     assert message.kwargs[0]["reply_markup"] == "MK"


### PR DESCRIPTION
## Summary
- prompt user to configure profile when coefficients are missing
- add tests ensuring profile hint shown once

## Testing
- `flake8 diabetes`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68904541b7f4832aac66fbb0f1277b94