### PR TITLE
[reporting] Add back navigation for custom report date

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -232,12 +232,21 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     logging.info("FREEFORM raw='%s'  user=%s", raw_text, user_id)
 
     if context.user_data.get("awaiting_report_date"):
+        text = update.message.text.strip().lower()
+        if "назад" in text or text == "/cancel":
+            context.user_data.pop("awaiting_report_date", None)
+            await update.message.reply_text(
+                "📋 Выберите действие:", reply_markup=menu_keyboard
+            )
+            return
         try:
             date_from = datetime.datetime.strptime(
                 update.message.text.strip(), "%Y-%m-%d"
             ).replace(tzinfo=datetime.timezone.utc)
         except ValueError:
-            await update.message.reply_text("❗ Некорректная дата. Используйте формат YYYY-MM-DD.")
+            await update.message.reply_text(
+                "❗ Некорректная дата. Используйте формат YYYY-MM-DD."
+            )
             return
         await send_report(update, context, date_from, "указанный период")
         context.user_data.pop("awaiting_report_date", None)

--- a/diabetes/reporting_handlers.py
+++ b/diabetes/reporting_handlers.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import datetime
 
-from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import (
+    Update,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    ReplyKeyboardMarkup,
+    KeyboardButton,
+)
 from telegram.ext import ContextTypes
 
 from diabetes.db import SessionLocal, Entry
@@ -121,8 +127,18 @@ async def report_period_callback(
     elif period == "custom":
         context.user_data["awaiting_report_date"] = True
         await query.edit_message_text(
-            "Введите дату начала отчёта в формате YYYY-MM-DD"
+            "Введите дату начала отчёта в формате YYYY-MM-DD\n"
+            "Отправьте «назад» для отмены."
         )
+        if getattr(query, "message", None):
+            await query.message.reply_text(
+                "Ожидаю дату…",
+                reply_markup=ReplyKeyboardMarkup(
+                    [[KeyboardButton("↩️ Назад")]],
+                    resize_keyboard=True,
+                    one_time_keyboard=True,
+                ),
+            )
     else:  # pragma: no cover - defensive
         await query.edit_message_text("Команда не распознана")
 


### PR DESCRIPTION
## Summary
- allow cancelling custom report date entry with a back button
- handle 'назад' or `/cancel` in freeform handler to exit date entry

## Testing
- `flake8 diabetes/`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_689047a2e90c832a8e7aa9dd45e62324