### PR TITLE
[handlers] Add explicit fallback and GPT command

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -196,6 +196,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "/profile - мой профиль\n"
         "/report - отчёт\n"
         "/sugar - расчёт сахара\n"
+        "/gpt - чат с GPT\n"
         "/cancel - отменить ввод\n"
         "/help - справка\n\n"
         "📲 Кнопки меню:\n"
@@ -233,6 +234,7 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("sugar", dose_handlers.sugar_start))
     app.add_handler(CommandHandler("cancel", dose_handlers.dose_cancel))
     app.add_handler(CommandHandler("help", help_command))
+    app.add_handler(CommandHandler("gpt", dose_handlers.chat_with_gpt))
     app.add_handler(
         MessageHandler(filters.Regex("^📄 Мой профиль$"), profile_handlers.profile_view)
     )

--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -375,7 +375,9 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     parsed = await parse_command(raw_text)
     logging.info("FREEFORM parsed=%s", parsed)
     if not parsed or parsed.get("action") != "add_entry":
-        await chat_with_gpt(update, context)
+        await update.message.reply_text(
+            "Не понял, воспользуйтесь /help или кнопками меню"
+        )
         return
 
     fields = parsed["fields"]

--- a/tests/test_freeform_handler_unknown.py
+++ b/tests/test_freeform_handler_unknown.py
@@ -1,0 +1,27 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import diabetes.dose_handlers as handlers
+
+
+class DummyMessage:
+    def __init__(self, text):
+        self.text = text
+        self.replies = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append((text, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_freeform_handler_unknown_command(monkeypatch):
+    message = DummyMessage("blah")
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+
+    monkeypatch.setattr(handlers, "parse_command", AsyncMock(return_value=None))
+
+    await handlers.freeform_handler(update, context)
+
+    assert message.replies
+    assert message.replies[0][0] == "Не понял, воспользуйтесь /help или кнопками меню"

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -37,6 +37,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert profile_handlers.profile_back in callbacks
     assert reporting_handlers.report_request in callbacks
     assert reporting_handlers.history_view in callbacks
+    assert dose_handlers.chat_with_gpt in callbacks
 
     start_cmd = [
         h for h in handlers if isinstance(h, CommandHandler) and h.callback is start_command
@@ -137,6 +138,13 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
         if isinstance(h, CommandHandler) and h.callback is reporting_handlers.report_request
     ]
     assert report_cmd and "report" in report_cmd[0].commands
+
+    gpt_cmd = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is dose_handlers.chat_with_gpt
+    ]
+    assert gpt_cmd and "gpt" in gpt_cmd[0].commands
 
     history_handlers = [
         h


### PR DESCRIPTION
## Summary
- send hint for unknown freeform text
- add /gpt command and update help
- test GPT handler registration and fallback

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689049e5eda4832aa09a38de62877abc