### PR TITLE
[profile] add back navigation

### DIFF
--- a/diabetes/ui.py
+++ b/diabetes/ui.py
@@ -14,7 +14,13 @@ from telegram import (
     KeyboardButton,
 )
 
-__all__ = ("menu_keyboard", "dose_keyboard", "sugar_keyboard", "confirm_keyboard")
+__all__ = (
+    "menu_keyboard",
+    "dose_keyboard",
+    "sugar_keyboard",
+    "confirm_keyboard",
+    "back_keyboard",
+)
 
 # ─────────────── Reply-клавиатуры (отображаются на экране чата) ───────────────
 
@@ -45,6 +51,12 @@ sugar_keyboard = ReplyKeyboardMarkup(
     resize_keyboard=True,
     one_time_keyboard=True,
     input_field_placeholder="Введите уровень сахара…",
+)
+
+back_keyboard = ReplyKeyboardMarkup(
+    keyboard=[[KeyboardButton("↩️ Назад")]],
+    resize_keyboard=True,
+    one_time_keyboard=True,
 )
 
 # ─────────────── Inline-клавиатуры (обрабатываются callback-ами) ───────────────


### PR DESCRIPTION
## Summary
- add reusable back keyboard
- handle "назад" in profile setup steps with back navigation
- allow leaving profile setup via "↩️ Назад"

## Testing
- `flake8 diabetes/`
- `DB_PASSWORD=test pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68904d466688832aae5f3d318140f2f8