### PR TITLE
[handlers] prompt for dish name and parse nutrition

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -492,8 +492,10 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
         run = send_message(
             thread_id=thread_id,
             content=(
-                "Определи количество углеводов и ХЕ на фото блюда. "
-                "Используй формат из системных инструкций ассистента."
+                "Определи **название** блюда и количество углеводов/ХЕ. Ответ:\n"
+                "<название блюда>\n"
+                "Углеводы: <...>\n"
+                "ХЕ: <...>"
             ),
             image_path=file_path,
             keep_image=True,

--- a/diabetes/functions.py
+++ b/diabetes/functions.py
@@ -97,6 +97,12 @@ def extract_nutrition_info(text: str) -> tuple[float | None, float | None]:
         >>> extract_nutrition_info("углеводы: 45 ± 5 г")
         (45.0, None)
     """
+    # Если ответ начинается с названия блюда, игнорируем первую строку
+    if isinstance(text, str):
+        lines = text.splitlines()
+        if len(lines) > 1:
+            text = "\n".join(lines[1:])
+
     carbs = xe = None
     # Парсим углеводы (carbs)
     m = re.search(

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -116,3 +116,10 @@ def test_extract_nutrition_info_invalid_xe():
     carbs, xe = extract_nutrition_info(text)
     assert carbs == 45
     assert xe is None
+
+
+def test_extract_nutrition_info_ignores_title_line():
+    text = "Борщ\nУглеводы: 25 г\nХЕ: 2"
+    carbs, xe = extract_nutrition_info(text)
+    assert carbs == 25
+    assert xe == 2

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -1,0 +1,90 @@
+import pytest
+from pathlib import Path
+from types import SimpleNamespace
+
+import diabetes.dose_handlers as dose_handlers
+
+
+class DummyMessage:
+    def __init__(self, text=None, photo=None):
+        self.text = text
+        self.photo = photo
+        self.replies = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append((text, kwargs))
+
+
+class DummyPhoto:
+    file_id = "fid"
+    file_unique_id = "uid"
+
+
+@pytest.mark.asyncio
+async def test_photo_prompt_includes_dish_name(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    async def fake_get_file(file_id):
+        class File:
+            async def download_to_drive(self, path):
+                Path(path).write_bytes(b"img")
+
+        return File()
+
+    async def fake_send_chat_action(*args, **kwargs):
+        pass
+
+    context = SimpleNamespace(
+        user_data={"thread_id": "tid"},
+        bot=SimpleNamespace(get_file=fake_get_file, send_chat_action=fake_send_chat_action),
+    )
+
+    captured = {}
+
+    class Run:
+        status = "completed"
+        thread_id = "tid"
+        id = "runid"
+
+    def fake_send_message(**kwargs):
+        captured["content"] = kwargs["content"]
+        return Run()
+
+    class DummyClient:
+        beta = SimpleNamespace(
+            threads=SimpleNamespace(
+                runs=SimpleNamespace(retrieve=lambda thread_id, run_id: Run()),
+                messages=SimpleNamespace(
+                    list=lambda thread_id: SimpleNamespace(
+                        data=[
+                            SimpleNamespace(
+                                role="assistant",
+                                content=[
+                                    SimpleNamespace(
+                                        text=SimpleNamespace(
+                                            value="Борщ\nУглеводы: 30 г\nХЕ: 2"
+                                        )
+                                    )
+                                ],
+                            )
+                        ]
+                    )
+                ),
+            )
+        )
+
+    monkeypatch.setattr(dose_handlers, "send_message", fake_send_message)
+    monkeypatch.setattr(dose_handlers, "_get_client", lambda: DummyClient())
+    monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
+
+    msg_photo = DummyMessage(photo=[DummyPhoto()])
+    update = SimpleNamespace(message=msg_photo, effective_user=SimpleNamespace(id=1))
+
+    await dose_handlers.photo_handler(update, context)
+
+    assert "название" in captured["content"]
+    # Final reply should include dish name from Vision response
+    assert any("Борщ" in reply[0] for reply in msg_photo.replies)
+    entry = context.user_data.get("pending_entry")
+    assert entry["carbs_g"] == 30
+    assert entry["xe"] == 2


### PR DESCRIPTION
## Summary
- ask Vision to return dish name along with carbs/XE values
- strip first line (dish name) when parsing nutrition info
- test Vision prompt and ensure parser ignores title line

## Testing
- `flake8 diabetes/ tests/test_handlers_vision_prompt.py tests/test_functions.py`
- `DB_PASSWORD=test pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_68904e01804c832ab7ff798852b44e39