### PR TITLE
[profile_handlers] Document per_message decision

### DIFF
--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -247,6 +247,11 @@ profile_conv = ConversationHandler(
         MessageHandler(filters.Regex("^↩️ Назад$"), profile_cancel),
         CommandHandler("cancel", profile_cancel),
     ],
+    # `per_message` stays False: state transitions rely on MessageHandlers, and
+    # enabling `per_message=True` would require all handlers to be
+    # `CallbackQueryHandler`, breaking the flow of text replies. The conversation
+    # only handles one profile edit at a time, so per-chat tracking is sufficient.
+    per_message=False,
 )
 
 


### PR DESCRIPTION
## Summary
- Explain why ConversationHandler for profile editing keeps `per_message=False`.

## Testing
- `flake8 diabetes`
- `pytest tests` *(fails: DB_PASSWORD environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68905c40b820832ab17c98428c95fb3c