### PR TITLE
[common_handlers] check entry owner before edit or delete

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -98,6 +98,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             if not entry:
                 await query.edit_message_text("Запись не найдена (уже удалена).")
                 return
+            if entry.telegram_id != update.effective_user.id:
+                await query.edit_message_text(
+                    "⚠️ Эта запись принадлежит другому пользователю."
+                )
+                return
             if action == "del":
                 session.delete(entry)
                 if not commit_session(session):


### PR DESCRIPTION
## Summary
- avoid editing or deleting entries owned by other users by checking telegram_id

## Testing
- `pytest tests/` *(fails: DB_PASSWORD environment variable must be set)*
- `flake8 diabetes/`

------
https://chatgpt.com/codex/tasks/task_e_68905ec219b4832aaab6de40786bf848