### PR TITLE
[dose_handlers] Sanitize freeform logging

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -230,7 +230,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handle freeform text commands for adding diary entries."""
     raw_text = update.message.text.strip()
     user_id = update.effective_user.id
-    logging.info("FREEFORM raw='%s'  user=%s", raw_text, user_id)
+    logging.info("FREEFORM raw='%s'  user=%s", _sanitize(raw_text), user_id)
 
     if context.user_data.get("awaiting_report_date"):
         text = update.message.text.strip().lower()


### PR DESCRIPTION
## Summary
- sanitize freeform text in dose handler logging using `_sanitize` to strip control chars and truncate long inputs

## Testing
- `python -m pytest tests/ -q` *(fails: DB_PASSWORD environment variable must be set)*
- `flake8 diabetes/`


------
https://chatgpt.com/codex/tasks/task_e_689060576c1c832a8fb6ad6693761aa2