### PR TITLE
[profile] explain per_message choice

### DIFF
--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -247,10 +247,10 @@ profile_conv = ConversationHandler(
         MessageHandler(filters.Regex("^↩️ Назад$"), profile_cancel),
         CommandHandler("cancel", profile_cancel),
     ],
-    # `per_message` stays False: state transitions rely on MessageHandlers, and
-    # enabling `per_message=True` would require all handlers to be
-    # `CallbackQueryHandler`, breaking the flow of text replies. The conversation
-    # only handles one profile edit at a time, so per-chat tracking is sufficient.
+    # Although the entry point is a ``CallbackQueryHandler``, subsequent steps
+    # depend on ``MessageHandler`` for text inputs.  Enabling
+    # ``per_message=True`` would store state per message and reset the
+    # conversation after each reply, so we keep per-chat tracking.
     per_message=False,
 )
 


### PR DESCRIPTION
## Summary
- document why `per_message` remains `False` for profile conversation handler

## Testing
- `DB_PASSWORD=test pytest -q`
- `flake8 diabetes/`


------
https://chatgpt.com/codex/tasks/task_e_689064e12d70832a80aa4e72bfd513d7