### PR TITLE
[profile] Add menu keyboard to /profile command

### DIFF
--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -80,6 +80,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         f"• КЧ: {cf} ммоль/л\n"
         f"• Целевой сахар: {target} ммоль/л" + warning_msg,
         parse_mode="Markdown",
+        reply_markup=menu_keyboard,
     )
 
 

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -5,6 +5,8 @@ from sqlalchemy.orm import sessionmaker
 from unittest.mock import MagicMock
 from telegram import InlineKeyboardMarkup
 
+from diabetes.ui import menu_keyboard
+
 from diabetes.db import Base, User, Profile
 
 
@@ -51,6 +53,7 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
     context = SimpleNamespace(args=args, user_data={})
 
     await handlers.profile_command(update, context)
+    assert message.markups[0] is menu_keyboard
     assert f"• ИКХ: {expected_icr} г/ед." in message.texts[0]
     assert f"• КЧ: {expected_cf} ммоль/л" in message.texts[0]
     assert f"• Целевой сахар: {expected_target} ммоль/л" in message.texts[0]


### PR DESCRIPTION
## Summary
- Show main menu keyboard after `/profile` command.
- Cover profile command reply markup in tests.

## Testing
- `flake8 diabetes/`
- `DB_PASSWORD=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68906d39257c832aa34767238fc78c47