### PR TITLE
[reporting_handlers] Format history view entries as HTML

### DIFF
--- a/diabetes/reporting_handlers.py
+++ b/diabetes/reporting_handlers.py
@@ -75,7 +75,10 @@ async def history_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         xe = entry.xe if entry.xe is not None else "—"
         dose = entry.dose if entry.dose is not None else "—"
         text = (
-            f"{day_str}: сахар {sugar}, углеводы {carbs} г ({xe} ХЕ), доза {dose}"
+            f"<b>{day_str}</b>\n"
+            f"🍭 Сахар: <b>{sugar}</b>\n"
+            f"🍞 Углеводы: <b>{carbs} г ({xe} ХЕ)</b>\n"
+            f"💉 Доза: <b>{dose}</b>"
         )
         markup = InlineKeyboardMarkup(
             [
@@ -89,7 +92,9 @@ async def history_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 ]
             ]
         )
-        await update.message.reply_text(text, reply_markup=markup)
+        await update.message.reply_text(
+            text, parse_mode="HTML", reply_markup=markup
+        )
 
     back_markup = InlineKeyboardMarkup(
         [[InlineKeyboardButton("🔙 Назад", callback_data="report_back")]]


### PR DESCRIPTION
## Summary
- Format history entries in `history_view` as a multi-line HTML message with icons
- Update `history_view` tests to assert HTML formatting and set default DB password

## Testing
- `flake8 diabetes/`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68906d11d34c832aa7b0656a1ac1ed01