### PR TITLE
[profile] Start interactive profile setup and help

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -240,7 +240,6 @@ def register_handlers(app: Application) -> None:
 
     app.add_handler(CommandHandler("start", start_command))
     app.add_handler(CommandHandler("menu", menu_command))
-    app.add_handler(CommandHandler("profile", profile_handlers.profile_command))
     app.add_handler(CommandHandler("report", reporting_handlers.report_request))
     app.add_handler(dose_handlers.dose_conv)
     app.add_handler(dose_handlers.sugar_conv)

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -24,7 +24,6 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     callbacks = [getattr(h, "callback", None) for h in handlers]
 
     assert start_command in callbacks
-    assert profile_handlers.profile_command in callbacks
     assert dose_handlers.freeform_handler in callbacks
     assert dose_handlers.photo_handler in callbacks
     assert dose_handlers.doc_handler in callbacks
@@ -44,12 +43,6 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     ]
     assert start_cmd and "start" in start_cmd[0].commands
 
-    profile_cmd = [
-        h
-        for h in handlers
-        if isinstance(h, CommandHandler) and h.callback is profile_handlers.profile_command
-    ]
-    assert profile_cmd and "profile" in profile_cmd[0].commands
 
     conv_handlers = [h for h in handlers if isinstance(h, ConversationHandler)]
     assert dose_handlers.dose_conv in conv_handlers
@@ -67,6 +60,14 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
         if isinstance(ep, CommandHandler)
     ]
     assert sugar_conv_cmds and "sugar" in sugar_conv_cmds[0].commands
+    profile_conv_cmd = [
+        ep
+        for ep in profile_handlers.profile_conv.entry_points
+        if isinstance(ep, CommandHandler)
+        and ep.callback is profile_handlers.profile_command
+        and "profile" in ep.commands
+    ]
+    assert profile_conv_cmd
     profile_conv_cb = [
         ep
         for ep in profile_handlers.profile_conv.entry_points


### PR DESCRIPTION
## Summary
- Start interactive profile editing when `/profile` is used without arguments
- Move detailed help to `/profile help`
- Adjust handler registration and tests for new flow

## Testing
- `flake8 diabetes`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907a266290832aa1bf5a59ae469a42