### PR TITLE
[gpt_client] Wrap text messages in block list

### DIFF
--- a/diabetes/gpt_client.py
+++ b/diabetes/gpt_client.py
@@ -80,7 +80,7 @@ def send_message(
                         "[OpenAI] Failed to delete %s: %s", image_path, e
                     )
     else:
-        content_block = content
+        content_block = [{"type": "text", "text": content}]
 
     # 2. Создаём сообщение в thread
     try:


### PR DESCRIPTION
## Summary
- ensure send_message wraps text-only messages into `[{"type": "text", "text": ...}]`
- guarantee `threads.messages.create` always receives a list of content blocks

## Testing
- `flake8 diabetes/`
- `pytest tests/test_gpt_client.py`

------
https://chatgpt.com/codex/tasks/task_e_68908584d2f0832ab86cb4cd22794c26