### PR TITLE
[config] move db password check

### DIFF
--- a/diabetes/config.py
+++ b/diabetes/config.py
@@ -35,8 +35,6 @@ DB_PORT = int(os.getenv("DB_PORT", 5432))
 DB_NAME = os.getenv("DB_NAME", "diabetes_bot")
 DB_USER = os.getenv("DB_USER", "diabetes_user")
 DB_PASSWORD = os.getenv("DB_PASSWORD")
-if not DB_PASSWORD:
-    raise ValueError("DB_PASSWORD environment variable must be set")
 
 # Optional directory containing custom fonts for PDF reports
 FONT_DIR = os.getenv("FONT_DIR")

--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -70,4 +70,6 @@ class Entry(Base):
 # ────────────────────── инициализация ────────────────────────
 def init_db() -> None:
     """Создать таблицы, если их ещё нет (для локального запуска)."""
+    if not DB_PASSWORD:
+        raise ValueError("DB_PASSWORD environment variable must be set")
     Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- avoid import-time DB_PASSWORD check in config
- validate DB_PASSWORD when initializing the database
- test config import and init_db behaviour when DB_PASSWORD missing

## Testing
- `pytest tests/test_config.py`
- `flake8 diabetes/`


------
https://chatgpt.com/codex/tasks/task_e_689088424464832aa533dcb798a17e09