### PR TITLE
[handlers] Add unit mix-up warnings and guidance

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -439,7 +439,23 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     try:
         quick = smart_input(raw_text)
     except ValueError as exc:
-        await update.message.reply_text(f"❗ Ошибка: {exc}")
+        msg = str(exc)
+        if "mismatched unit for sugar" in msg:
+            await update.message.reply_text(
+                "❗ Сахар указывается в ммоль/л, не в XE."
+            )
+        elif "mismatched unit for dose" in msg:
+            await update.message.reply_text(
+                "❗ Доза указывается в ед., не в ммоль."
+            )
+        elif "mismatched unit for xe" in msg:
+            await update.message.reply_text(
+                "❗ ХЕ указываются числом, без ммоль/л и ед."
+            )
+        else:
+            await update.message.reply_text(
+                "Не удалось распознать значения, используйте сахар=5 xe=1 dose=2"
+            )
         return
     if any(v is not None for v in quick.values()):
         sugar = quick["sugar"]

--- a/diabetes/functions.py
+++ b/diabetes/functions.py
@@ -246,12 +246,12 @@ def smart_input(message: str) -> dict[str, float | None]:
     ):
         raise ValueError("mismatched unit for sugar")
     if re.search(
-        r"\b(?:xe|хе)\s*[:=]?\s*\d+[.,]?\d*\s*(?:ммоль/?л|mmol/?l|ед)\b(?![=:])",
+        r"\b(?:xe|хе)\s*[:=]?\s*\d+[.,]?\d*\s*(?:ммоль(?:/л)?|mmol(?:/l)?|ед)\b(?![=:])",
         text,
     ):
         raise ValueError("mismatched unit for xe")
     if re.search(
-        r"\b(?:dose|доза|болюс)\s*[:=]?\s*\d+[.,]?\d*\s*(?:ммоль/?л|mmol/?l|xe|хе)\b(?![=:])",
+        r"\b(?:dose|доза|болюс)\s*[:=]?\s*\d+[.,]?\d*\s*(?:ммоль(?:/л)?|mmol(?:/l)?|xe|хе)\b(?![=:])",
         text,
     ):
         raise ValueError("mismatched unit for dose")

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -153,3 +153,8 @@ def test_smart_input_unit_mixup():
 def test_smart_input_unit_mixup_xe():
     with pytest.raises(ValueError):
         smart_input("xe 5 ммоль/л")
+
+
+def test_smart_input_unit_mixup_dose():
+    with pytest.raises(ValueError):
+        smart_input("доза 7 ммоль")

--- a/tests/test_handlers_freeform_units.py
+++ b/tests/test_handlers_freeform_units.py
@@ -1,0 +1,56 @@
+import pytest
+from types import SimpleNamespace
+import diabetes.dose_handlers as handlers
+
+
+class DummyMessage:
+    def __init__(self, text):
+        self.text = text
+        self.replies = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append((text, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_freeform_handler_warns_on_sugar_unit_mix():
+    message = DummyMessage("сахар 5 XE")
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+
+    await handlers.freeform_handler(update, context)
+
+    assert message.replies
+    text, _ = message.replies[0]
+    assert "ммоль/л" in text and "Сахар" in text
+
+
+@pytest.mark.asyncio
+async def test_freeform_handler_warns_on_dose_unit_mix():
+    message = DummyMessage("доза 7 ммоль")
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+
+    await handlers.freeform_handler(update, context)
+
+    assert message.replies
+    text, _ = message.replies[0]
+    assert "ед" in text.lower() and "доза" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_freeform_handler_guidance_on_valueerror(monkeypatch):
+    message = DummyMessage("whatever")
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+
+    def fake_smart_input(_):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(handlers, "smart_input", fake_smart_input)
+
+    await handlers.freeform_handler(update, context)
+
+    assert message.replies
+    text, _ = message.replies[0]
+    assert "Не удалось распознать значения" in text


### PR DESCRIPTION
## Summary
- Warn users when smart input uses mismatched units and provide guidance if parsing fails
- Improve smart_input unit validation to catch incorrect mmol and XE usage
- Test freeform handler and smart_input for unit mix-ups and guidance responses

## Testing
- `flake8 diabetes/ tests/test_handlers_freeform_units.py tests/test_functions.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68909cef17b4832a9aee768b7384f5d7