### PR TITLE
[functions] add smart input tests and validation

### DIFF
--- a/tests/test_smart_input.py
+++ b/tests/test_smart_input.py
@@ -1,0 +1,21 @@
+import pytest
+
+from diabetes.functions import smart_input
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    [
+        ("sugar=7 xe=2.5 dose=4", {"sugar": 7.0, "xe": 2.5, "dose": 4.0}),
+        ("7 ммоль/л, 3 XE", {"sugar": 7.0, "xe": 3.0, "dose": None}),
+        ("сахар 5 XE 3.2 доза 6", {"sugar": 5.0, "xe": 3.2, "dose": 6.0}),
+        ("Xe 1.5 dose 2", {"sugar": None, "xe": 1.5, "dose": 2.0}),
+    ],
+)
+def test_smart_input_valid_cases(message, expected):
+    assert smart_input(message) == expected
+
+
+def test_smart_input_invalid_dose():
+    with pytest.raises(ValueError):
+        smart_input("доза=abc")


### PR DESCRIPTION
## Summary
- validate that metric labels without numbers raise ValueError in `smart_input`
- relax mismatched-unit regex for sugar to allow chained values
- add tests covering various smart input scenarios and edge cases

## Testing
- `flake8 diabetes/ tests/test_smart_input.py`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6890a06860dc832a899a6c2a04c7a975