### PR TITLE
[common] Add smart-input help menu option

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -205,6 +205,17 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await update.message.reply_text(text, reply_markup=menu_keyboard)
 
 
+async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Explain the smart-input syntax for quick diary entries."""
+
+    text = (
+        "🕹 Быстрый ввод позволяет записать сахар, ХЕ и дозу в одном сообщении.\n"
+        "Используйте формат: `сахар=<ммоль/л> xe=<ХЕ> dose=<ед>` или свободный текст,\n"
+        "например: `5 ммоль/л 3хе 2ед`. Можно указывать только нужные значения."
+    )
+    await update.message.reply_text(text, parse_mode="Markdown")
+
+
 def register_handlers(app: Application) -> None:
     """Register bot handlers on the provided ``Application`` instance.
 
@@ -242,6 +253,9 @@ def register_handlers(app: Application) -> None:
         MessageHandler(filters.Regex("^📷 Фото еды$"), dose_handlers.photo_prompt)
     )
     app.add_handler(
+        MessageHandler(filters.Regex("^🕹 Быстрый ввод$"), smart_input_help)
+    )
+    app.add_handler(
         MessageHandler(filters.Regex("^ℹ️ Помощь$"), help_command)
     )
     app.add_handler(
@@ -274,5 +288,6 @@ __all__ = [
     "start_command",
     "menu_command",
     "help_command",
+    "smart_input_help",
     "register_handlers",
 ]

--- a/diabetes/ui.py
+++ b/diabetes/ui.py
@@ -29,7 +29,7 @@ menu_keyboard = ReplyKeyboardMarkup(
         [KeyboardButton("📷 Фото еды"), KeyboardButton("🩸 Уровень сахара")],
         [KeyboardButton("💉 Доза инсулина"), KeyboardButton("📊 История")],
         [KeyboardButton("📈 Отчёт"), KeyboardButton("📄 Мой профиль")],
-        [KeyboardButton("ℹ️ Помощь")],
+        [KeyboardButton("🕹 Быстрый ввод"), KeyboardButton("ℹ️ Помощь")],
     ],
     resize_keyboard=True,
     one_time_keyboard=False,

--- a/tests/test_smart_input_help.py
+++ b/tests/test_smart_input_help.py
@@ -1,0 +1,30 @@
+import pytest
+from types import SimpleNamespace
+
+import diabetes.common_handlers as handlers
+
+
+class DummyMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.replies = []
+        self.kwargs = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_smart_input_help_responds_with_hint():
+    message = DummyMessage("🕹 Быстрый ввод")
+    update = SimpleNamespace(message=message)
+    context = SimpleNamespace()
+
+    await handlers.smart_input_help(update, context)
+
+    assert message.replies, "Expected at least one reply"
+    reply = message.replies[0]
+    assert "сахар=" in reply
+    assert "xe=" in reply or "XE" in reply
+    assert "dose=" in reply or "ед" in reply


### PR DESCRIPTION
## Summary
- add "Quick input" button to main menu keyboard
- add smart_input_help handler and register message handler
- test quick input help replies with syntax prompt

## Testing
- `flake8 diabetes tests/test_smart_input_help.py`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_6890ab0449e0832abe7a635aa013d9cc