### PR TITLE
[ci] Add tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          pip install pytest-cov
+      - name: Run tests
+        run: |
+          set -o pipefail
+          pytest --cov=diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85 | tee coverage.txt
+          cat coverage.txt >> $GITHUB_STEP_SUMMARY
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            coverage.txt


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install dependencies and run tests with coverage

## Testing
- `ruff check diabetes tests`
- `pytest --cov=diabetes --cov-report=term-missing --cov-fail-under=85` *(fails: Required test coverage of 85% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6890b4c51718832a962e9419cf8b5916