### PR TITLE
[ci] Add pytest-cov to dev dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,6 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-          pip install pytest-cov
       - name: Run tests
         run: |
           set -o pipefail

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 ruff
 pre-commit
+pytest-cov


### PR DESCRIPTION
## Summary
- add `pytest-cov` to development requirements
- install dev requirements in CI workflow before running tests

## Testing
- `ruff check diabetes tests`
- `pytest --cov=diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85` *(fails: Required test coverage of 85% not reached)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890b6a46918832aa8097e6d710aca60