### PR TITLE
[reminders] add personal reminder engine

### DIFF
--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -68,6 +68,29 @@ class Entry(Base):
     gpt_summary = Column(Text)
 
 
+class Reminder(Base):
+    __tablename__ = "reminders"
+
+    id = Column(Integer, primary_key=True, index=True)
+    telegram_id = Column(BigInteger, ForeignKey("users.telegram_id"))
+    type = Column(String, nullable=False)
+    time = Column(String)  # HH:MM format for daily reminders
+    interval_hours = Column(Integer)  # for repeating reminders
+    minutes_after = Column(Integer)  # for after-meal reminders
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now())
+    user = relationship("User")
+
+
+class ReminderLog(Base):
+    __tablename__ = "reminder_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    reminder_id = Column(Integer, ForeignKey("reminders.id"))
+    telegram_id = Column(BigInteger)
+    action = Column(String)  # triggered, snoozed, cancelled
+    event_time = Column(TIMESTAMP(timezone=True), server_default=func.now())
+
+
 # ────────────────────── инициализация ────────────────────────
 def init_db() -> None:
     """Создать таблицы, если их ещё нет (для локального запуска)."""

--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -1,0 +1,205 @@
+"""Handlers for personal reminders."""
+
+from __future__ import annotations
+
+from datetime import time, timedelta
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes
+
+from diabetes.db import SessionLocal, Reminder, ReminderLog
+from .common_handlers import commit_session
+
+MAX_REMINDERS = 5
+
+
+def _describe(rem: Reminder) -> str:
+    if rem.type == "sugar":
+        if rem.time:
+            return f"Замерить сахар {rem.time}"
+        return f"Замерить сахар каждые {rem.interval_hours} ч"
+    if rem.type == "long_insulin":
+        return f"Длинный инсулин {rem.time}"
+    if rem.type == "medicine":
+        return f"Таблетки/лекарство {rem.time}"
+    if rem.type == "xe_after":
+        return f"Проверить ХЕ через {rem.minutes_after} мин"
+    return rem.type
+
+
+def schedule_reminder(rem: Reminder, job_queue) -> None:
+    name = f"reminder_{rem.id}"
+    if rem.type in {"sugar", "long_insulin", "medicine"}:
+        if rem.time:
+            hh, mm = map(int, rem.time.split(":"))
+            job_queue.run_daily(
+                reminder_job,
+                time=time(hour=hh, minute=mm),
+                data={"reminder_id": rem.id, "chat_id": rem.telegram_id},
+                name=name,
+            )
+        elif rem.interval_hours:
+            job_queue.run_repeating(
+                reminder_job,
+                interval=timedelta(hours=rem.interval_hours),
+                data={"reminder_id": rem.id, "chat_id": rem.telegram_id},
+                name=name,
+            )
+    # xe_after reminders are scheduled when entry is logged
+
+
+def schedule_all(job_queue) -> None:
+    with SessionLocal() as session:
+        reminders = session.query(Reminder).all()
+    for rem in reminders:
+        schedule_reminder(rem, job_queue)
+
+
+async def reminders_list(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = update.effective_user.id
+    with SessionLocal() as session:
+        rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
+    if not rems:
+        await update.message.reply_text("У вас нет напоминаний.")
+        return
+    lines = [f"{r.id}. {_describe(r)}" for r in rems]
+    await update.message.reply_text("\n".join(lines))
+
+
+async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = update.effective_user.id
+    args = context.args
+    if not args or len(args) < 2:
+        await update.message.reply_text(
+            "Формат: /addreminder [id] <type> <time|interval>",
+        )
+        return
+    idx = 0
+    rtype: str
+    val: str
+    with SessionLocal() as session:
+        if args[0].isdigit():
+            rid = int(args[0])
+            idx = 1
+            reminder = session.get(Reminder, rid)
+            if not reminder:
+                await update.message.reply_text("Напоминание не найдено.")
+                return
+        else:
+            reminder = None
+        rtype = args[idx]
+        val = args[idx + 1]
+        if reminder is None:
+            count = (
+                session.query(Reminder)
+                .filter_by(telegram_id=user_id)
+                .count()
+            )
+            if count >= MAX_REMINDERS:
+                await update.message.reply_text(
+                    "Можно создать не более 5 напоминаний.",
+                )
+                return
+            reminder = Reminder(telegram_id=user_id, type=rtype)
+            session.add(reminder)
+        reminder.type = rtype
+        reminder.time = None
+        reminder.interval_hours = None
+        reminder.minutes_after = None
+        if rtype == "sugar":
+            if ":" in val:
+                reminder.time = val
+            else:
+                reminder.interval_hours = int(val)
+        elif rtype in {"long_insulin", "medicine"}:
+            reminder.time = val
+        elif rtype == "xe_after":
+            reminder.minutes_after = int(val)
+        commit_session(session)
+        rid = reminder.id
+    for job in context.job_queue.get_jobs_by_name(f"reminder_{rid}"):
+        job.schedule_removal()
+    schedule_reminder(reminder, context.job_queue)
+    await update.message.reply_text(f"Сохранено: {_describe(reminder)}")
+
+
+async def delete_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not context.args:
+        await update.message.reply_text("Укажите ID: /delreminder <id>")
+        return
+    rid = int(context.args[0])
+    with SessionLocal() as session:
+        rem = session.get(Reminder, rid)
+        if not rem:
+            await update.message.reply_text("Не найдено")
+            return
+        session.delete(rem)
+        commit_session(session)
+    for job in context.job_queue.get_jobs_by_name(f"reminder_{rid}"):
+        job.schedule_removal()
+    await update.message.reply_text("Удалено")
+
+
+async def reminder_job(context: ContextTypes.DEFAULT_TYPE) -> None:
+    data = context.job.data
+    rid = data["reminder_id"]
+    chat_id = data["chat_id"]
+    with SessionLocal() as session:
+        rem = session.get(Reminder, rid)
+        if not rem:
+            return
+        session.add(
+            ReminderLog(reminder_id=rid, telegram_id=chat_id, action="trigger")
+        )
+        commit_session(session)
+        text = _describe(rem)
+    keyboard = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    "Отложить 10 мин", callback_data=f"remind_snooze:{rid}"
+                ),
+                InlineKeyboardButton("Отмена", callback_data=f"remind_cancel:{rid}"),
+            ]
+        ]
+    )
+    await context.bot.send_message(chat_id=chat_id, text=text, reply_markup=keyboard)
+
+
+async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    action, rid_str = query.data.split(":")
+    rid = int(rid_str)
+    chat_id = update.effective_user.id
+    with SessionLocal() as session:
+        session.add(
+            ReminderLog(reminder_id=rid, telegram_id=chat_id, action=action)
+        )
+        commit_session(session)
+    if action == "remind_snooze":
+        context.job_queue.run_once(
+            reminder_job,
+            when=timedelta(minutes=10),
+            data={"reminder_id": rid, "chat_id": chat_id},
+            name=f"reminder_{rid}",
+        )
+        await query.edit_message_text("⏰ Отложено на 10 минут")
+    else:
+        await query.edit_message_text("❌ Напоминание отменено")
+
+
+def schedule_after_meal(user_id: int, job_queue) -> None:
+    with SessionLocal() as session:
+        rems = (
+            session.query(Reminder)
+            .filter_by(telegram_id=user_id, type="xe_after")
+            .all()
+        )
+    for rem in rems:
+        job_queue.run_once(
+            reminder_job,
+            when=timedelta(minutes=rem.minutes_after),
+            data={"reminder_id": rem.id, "chat_id": user_id},
+            name=f"reminder_{rem.id}",
+        )

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1,0 +1,129 @@
+import pytest
+from types import SimpleNamespace
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from diabetes.db import Base, User, Reminder, ReminderLog
+import diabetes.reminder_handlers as handlers
+from diabetes.common_handlers import commit_session
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+class DummyBot:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, chat_id, text, **kwargs):
+        self.messages.append((chat_id, text, kwargs))
+
+
+class DummyJob:
+    def __init__(self, callback, data, name):
+        self.callback = callback
+        self.data = data
+        self.name = name
+        self.removed = False
+
+    def schedule_removal(self):
+        self.removed = True
+
+
+class DummyJobQueue:
+    def __init__(self):
+        self.jobs = []
+
+    def run_daily(self, callback, time, data=None, name=None):
+        self.jobs.append(DummyJob(callback, data, name))
+
+    def run_repeating(self, callback, interval, data=None, name=None):
+        self.jobs.append(DummyJob(callback, data, name))
+
+    def run_once(self, callback, when, data=None, name=None):
+        self.jobs.append(DummyJob(callback, data, name))
+
+    def get_jobs_by_name(self, name):
+        return [j for j in self.jobs if j.name == name]
+
+
+@pytest.mark.asyncio
+async def test_create_update_delete_reminder(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    handlers.SessionLocal = TestSession
+    handlers.commit_session = commit_session
+
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.commit()
+
+    job_queue = DummyJobQueue()
+
+    msg = DummyMessage()
+    update = SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(args=["sugar", "23:00"], job_queue=job_queue)
+    await handlers.add_reminder(update, context)
+    assert "Сохранено" in msg.texts[0]
+
+    with TestSession() as session:
+        rems = session.query(Reminder).all()
+        assert len(rems) == 1
+        rid = rems[0].id
+
+    msg2 = DummyMessage()
+    update2 = SimpleNamespace(message=msg2, effective_user=SimpleNamespace(id=1))
+    context2 = SimpleNamespace(args=[str(rid), "sugar", "6"], job_queue=job_queue)
+    await handlers.add_reminder(update2, context2)
+    with TestSession() as session:
+        rem = session.get(Reminder, rid)
+        assert rem.interval_hours == 6
+
+    msg3 = DummyMessage()
+    update3 = SimpleNamespace(message=msg3, effective_user=SimpleNamespace(id=1))
+    context3 = SimpleNamespace(args=[str(rid)], job_queue=job_queue)
+    await handlers.delete_reminder(update3, context3)
+    with TestSession() as session:
+        assert session.query(Reminder).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_trigger_job_logs(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    handlers.SessionLocal = TestSession
+    handlers.commit_session = commit_session
+
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time="23:00"))
+        session.commit()
+
+    job_queue = DummyJobQueue()
+    with TestSession() as session:
+        rem_db = session.get(Reminder, 1)
+        rem = Reminder(
+            id=rem_db.id,
+            telegram_id=rem_db.telegram_id,
+            type=rem_db.type,
+            time=rem_db.time,
+        )
+    handlers.schedule_reminder(rem, job_queue)
+    bot = DummyBot()
+    context = SimpleNamespace(
+        bot=bot,
+        job=SimpleNamespace(data={"reminder_id": 1, "chat_id": 1}),
+        job_queue=job_queue,
+    )
+    await handlers.reminder_job(context)
+    assert bot.messages[0][1].startswith("Замерить сахар")
+    with TestSession() as session:
+        log = session.query(ReminderLog).first()
+        assert log.action == "trigger"


### PR DESCRIPTION
## Summary
- implement SQLAlchemy models and handlers for user reminders with JobQueue
- expose `/reminders`, `/addreminder`, `/delreminder` commands and inline snooze/cancel
- log reminder activity and test create/update/delete and trigger flows

## Testing
- `ruff check diabetes tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890bcb44b50832aa585ca6737e8a9f4