### PR TITLE
[profile] add BG thresholds

### DIFF
--- a/alembic/versions/9b1c2d3e4f5a_add_profile_thresholds.py
+++ b/alembic/versions/9b1c2d3e4f5a_add_profile_thresholds.py
@@ -1,0 +1,29 @@
+"""add profile thresholds
+
+Revision ID: 9b1c2d3e4f5a
+Revises: 1a2b3c4d5e6f
+Create Date: 2025-08-29 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '9b1c2d3e4f5a'
+down_revision: Union[str, None] = '1a2b3c4d5e6f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("profiles", sa.Column("low_threshold", sa.Float(), nullable=True))
+    op.add_column("profiles", sa.Column("high_threshold", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("profiles", "high_threshold")
+    op.drop_column("profiles", "low_threshold")

--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -47,6 +47,8 @@ class Profile(Base):
     icr = Column(Float)  # г углеводов на 1 Е инсулина
     cf = Column(Float)  # коэффициент коррекции
     target_bg = Column(Float)  # целевой сахар
+    low_threshold = Column(Float)  # нижний порог сахара
+    high_threshold = Column(Float)  # верхний порог сахара
     user = relationship("User")
 
 

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -49,7 +49,7 @@ async def test_profile_command_commit_failure(monkeypatch, caplog):
 
     message = DummyMessage()
     update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(args=["10", "2", "6"], user_data={})
+    context = SimpleNamespace(args=["10", "2", "6", "4", "9"], user_data={})
 
     with caplog.at_level(logging.ERROR):
         await profile_handlers.profile_command(update, context)

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -25,17 +25,17 @@ class DummyMessage:
 
 
 @pytest.mark.parametrize(
-    "args, expected_icr, expected_cf, expected_target",
+    "args, expected_icr, expected_cf, expected_target, expected_low, expected_high",
     [
-        (["8", "3", "6"], "8.0", "3.0", "6.0"),
-        (["8,5", "3,1", "6,7"], "8.5", "3.1", "6.7"),
-        (["icr=8", "cf=3", "target=6"], "8.0", "3.0", "6.0"),
-        (["target=6", "icr=8", "cf=3"], "8.0", "3.0", "6.0"),
-        (["i=8", "c=3", "t=6"], "8.0", "3.0", "6.0"),
+        (["8", "3", "6", "4", "9"], "8.0", "3.0", "6.0", "4.0", "9.0"),
+        (["8,5", "3,1", "6,7", "3,2", "8,2"], "8.5", "3.1", "6.7", "3.2", "8.2"),
+        (["icr=8", "cf=3", "target=6", "low=4", "high=9"], "8.0", "3.0", "6.0", "4.0", "9.0"),
+        (["target=6", "icr=8", "cf=3", "low=4", "high=9"], "8.0", "3.0", "6.0", "4.0", "9.0"),
+        (["i=8", "c=3", "t=6", "l=4", "h=9"], "8.0", "3.0", "6.0", "4.0", "9.0"),
     ],
 )
 @pytest.mark.asyncio
-async def test_profile_command_and_view(monkeypatch, args, expected_icr, expected_cf, expected_target):
+async def test_profile_command_and_view(monkeypatch, args, expected_icr, expected_cf, expected_target, expected_low, expected_high):
     import os
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
@@ -61,6 +61,8 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
     assert f"• ИКХ: {expected_icr} г/ед." in message.texts[0]
     assert f"• КЧ: {expected_cf} ммоль/л" in message.texts[0]
     assert f"• Целевой сахар: {expected_target} ммоль/л" in message.texts[0]
+    assert f"• Низкий порог: {expected_low} ммоль/л" in message.texts[0]
+    assert f"• Высокий порог: {expected_high} ммоль/л" in message.texts[0]
 
     message2 = DummyMessage()
     update2 = SimpleNamespace(message=message2, effective_user=SimpleNamespace(id=123))
@@ -70,6 +72,8 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
     assert f"• ИКХ: {expected_icr} г/ед." in message2.texts[0]
     assert f"• КЧ: {expected_cf} ммоль/л" in message2.texts[0]
     assert f"• Целевой сахар: {expected_target} ммоль/л" in message2.texts[0]
+    assert f"• Низкий порог: {expected_low} ммоль/л" in message2.texts[0]
+    assert f"• Высокий порог: {expected_high} ммоль/л" in message2.texts[0]
     markup = message2.markups[0]
     assert isinstance(markup, InlineKeyboardMarkup)
     buttons = [b for row in markup.inline_keyboard for b in row]
@@ -81,9 +85,11 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
 @pytest.mark.parametrize(
     "args",
     [
-        ["0", "3", "6"],
-        ["8", "0", "6"],
-        ["8", "3", "-1"],
+        ["0", "3", "6", "4", "9"],
+        ["8", "0", "6", "4", "9"],
+        ["8", "3", "-1", "4", "9"],
+        ["8", "3", "6", "-1", "9"],
+        ["8", "3", "6", "4", "3"],
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add low/high glucose thresholds to user profile model
- handle low/high thresholds in /profile command and conversation
- show thresholds in profile view and cover with tests

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6890c0b9103c832aa3005c17ec518619