### PR TITLE
[db] Add alerts table

### DIFF
--- a/alembic/versions/a64429805715_create_alerts_table.py
+++ b/alembic/versions/a64429805715_create_alerts_table.py
@@ -1,0 +1,36 @@
+"""create alerts table
+
+Revision ID: a64429805715
+Revises: 9b1c2d3e4f5a
+Create Date: 2025-08-04 14:30:00.760979
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a64429805715'
+down_revision: Union[str, None] = '9b1c2d3e4f5a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'alerts',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.BigInteger(), sa.ForeignKey('users.telegram_id')),
+        sa.Column('sugar', sa.Float()),
+        sa.Column('type', sa.String()),
+        sa.Column('ts', sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+        sa.Column('resolved', sa.Boolean(), server_default=sa.text('false'), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('alerts')

--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -70,6 +70,18 @@ class Entry(Base):
     gpt_summary = Column(Text)
 
 
+class Alert(Base):
+    __tablename__ = "alerts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(BigInteger, ForeignKey("users.telegram_id"))
+    sugar = Column(Float)
+    type = Column(String)
+    ts = Column(TIMESTAMP(timezone=True), server_default=func.now())
+    resolved = Column(Boolean, default=False)
+    user = relationship("User")
+
+
 class Reminder(Base):
     __tablename__ = "reminders"
 


### PR DESCRIPTION
## Summary
- add `Alert` ORM model for user sugar alerts
- create Alembic migration for `alerts` table

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6890c3469cf0832abf6b83e7a7a45156