### PR TITLE
[handlers] Add alert statistics command

### DIFF
--- a/diabetes/alert_handlers.py
+++ b/diabetes/alert_handlers.py
@@ -1,0 +1,35 @@
+"""Handlers related to alert statistics."""
+
+from __future__ import annotations
+
+import datetime
+
+from telegram import Update
+from telegram.ext import ContextTypes
+from sqlalchemy import func
+
+from diabetes.db import SessionLocal, Alert
+
+
+async def alert_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Display count of alerts for the last seven days grouped by type."""
+    user_id = update.effective_user.id
+    now = datetime.datetime.now(datetime.timezone.utc)
+    week_ago = now - datetime.timedelta(days=7)
+    with SessionLocal() as session:
+        rows = (
+            session.query(Alert.type, func.count(Alert.id))
+            .filter(Alert.user_id == user_id, Alert.ts > week_ago)
+            .group_by(Alert.type)
+            .all()
+        )
+    stats = {atype: count for atype, count in rows}
+    hypo = stats.get("hypo", 0)
+    hyper = stats.get("hyper", 0)
+    await update.message.reply_text(
+        f"За 7\u202Fдн.: гипо\u202F{hypo}, гипер\u202F{hyper}"
+    )
+
+
+__all__ = ["alert_stats"]
+

--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -232,7 +232,7 @@ def register_handlers(app: Application) -> None:
 
     # Import inside the function to avoid heavy imports at module import time
     # (for example OpenAI client initialization).
-    from . import dose_handlers, profile_handlers, reporting_handlers, reminder_handlers
+    from . import dose_handlers, profile_handlers, reporting_handlers, reminder_handlers, alert_handlers
 
     app.add_handler(onboarding_conv)
     app.add_handler(CommandHandler("menu", menu_command))
@@ -247,6 +247,7 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("reminders", reminder_handlers.reminders_list))
     app.add_handler(CommandHandler("addreminder", reminder_handlers.add_reminder))
     app.add_handler(CommandHandler("delreminder", reminder_handlers.delete_reminder))
+    app.add_handler(CommandHandler("alertstats", alert_handlers.alert_stats))
     app.add_handler(PollAnswerHandler(onboarding_poll_answer))
     app.add_handler(
         MessageHandler(filters.Regex("^📄 Мой профиль$"), profile_handlers.profile_view)

--- a/tests/test_alert_stats.py
+++ b/tests/test_alert_stats.py
@@ -1,0 +1,66 @@
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from diabetes.db import Base, Alert, User
+import diabetes.alert_handlers as alert_handlers
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts: list[str] = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+
+@pytest.mark.asyncio
+async def test_alert_stats_counts(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    alert_handlers.SessionLocal = TestSession
+
+    fixed_now = datetime.datetime(2024, 1, 10, tzinfo=datetime.timezone.utc)
+
+    class DummyDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(
+        alert_handlers,
+        "datetime",
+        SimpleNamespace(
+            datetime=DummyDateTime,
+            timedelta=datetime.timedelta,
+            timezone=datetime.timezone,
+        ),
+    )
+
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.add(
+            Alert(user_id=1, type="hypo", ts=fixed_now - datetime.timedelta(days=1))
+        )
+        session.add(
+            Alert(user_id=1, type="hyper", ts=fixed_now - datetime.timedelta(days=2))
+        )
+        session.add(
+            Alert(user_id=1, type="hyper", ts=fixed_now - datetime.timedelta(days=8))
+        )
+        session.add(
+            Alert(user_id=2, type="hypo", ts=fixed_now - datetime.timedelta(days=1))
+        )
+        session.commit()
+
+    msg = DummyMessage()
+    update = SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace()
+
+    await alert_handlers.alert_stats(update, context)
+    assert msg.texts == ["За 7\u202Fдн.: гипо\u202F1, гипер\u202F1"]
+


### PR DESCRIPTION
## Summary
- add `alert_stats` handler to show weekly hypo/hyper counts
- expose `/alertstats` command in handler registry
- cover alert statistics with tests

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6890c539b8e8832ab41dbfa338edaa7a