### PR TITLE
[alerts] Add alert handlers and tests

### DIFF
--- a/diabetes/alert_handlers.py
+++ b/diabetes/alert_handlers.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from telegram.ext import ContextTypes
+
+from diabetes.db import SessionLocal, Alert, Profile
+from diabetes.common_handlers import commit_session
+
+MAX_REPEATS = 3
+
+
+def schedule_alert(user_id: int, job_queue, count: int = 1) -> None:
+    job_queue.run_once(
+        alert_job,
+        when=0,
+        data={"user_id": user_id, "count": count},
+        name=f"alert_{user_id}",
+    )
+
+
+def evaluate_sugar(user_id: int, sugar: float, job_queue) -> None:
+    with SessionLocal() as session:
+        profile = session.get(Profile, user_id)
+        low = profile.low_threshold if profile else None
+        high = profile.high_threshold if profile else None
+
+        active = (
+            session.query(Alert)
+            .filter_by(user_id=user_id, resolved=False)
+            .all()
+        )
+
+        if (low is not None and sugar < low) or (high is not None and sugar > high):
+            atype = "low" if low is not None and sugar < low else "high"
+            alert = Alert(user_id=user_id, sugar=sugar, type=atype)
+            session.add(alert)
+            commit_session(session)
+            schedule_alert(user_id, job_queue)
+        else:
+            for a in active:
+                a.resolved = True
+            commit_session(session)
+            for job in job_queue.get_jobs_by_name(f"alert_{user_id}"):
+                job.schedule_removal()
+
+
+async def alert_job(context: ContextTypes.DEFAULT_TYPE) -> None:
+    data = context.job.data
+    user_id = data["user_id"]
+    count = data.get("count", 1)
+    with SessionLocal() as session:
+        active = (
+            session.query(Alert)
+            .filter_by(user_id=user_id, resolved=False)
+            .first()
+        )
+    if not active:
+        return
+    if count >= MAX_REPEATS:
+        return
+    schedule_alert(user_id, context.job_queue, count=count + 1)

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,107 @@
+import pytest
+from types import SimpleNamespace
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from diabetes.db import Base, User, Profile, Alert
+import diabetes.alert_handlers as handlers
+from diabetes.common_handlers import commit_session
+
+
+class DummyJob:
+    def __init__(self, callback, data, name):
+        self.callback = callback
+        self.data = data
+        self.name = name
+        self.removed = False
+
+    def schedule_removal(self):
+        self.removed = True
+
+
+class DummyJobQueue:
+    def __init__(self):
+        self.jobs = []
+
+    def run_once(self, callback, when, data=None, name=None):
+        self.jobs.append(DummyJob(callback, data, name))
+
+    def get_jobs_by_name(self, name):
+        return [j for j in self.jobs if j.name == name]
+
+
+@pytest.mark.asyncio
+async def test_threshold_evaluation():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    handlers.SessionLocal = TestSession
+    handlers.commit_session = commit_session
+
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t1"))
+        session.add(Profile(telegram_id=1, low_threshold=4, high_threshold=8))
+        session.add(User(telegram_id=2, thread_id="t2"))
+        session.add(Profile(telegram_id=2, low_threshold=4, high_threshold=8))
+        session.commit()
+
+    job_queue_low = DummyJobQueue()
+    handlers.evaluate_sugar(1, 3, job_queue_low)
+    with TestSession() as session:
+        alert = session.query(Alert).filter_by(user_id=1).first()
+        assert alert.type == "low"
+    assert job_queue_low.get_jobs_by_name("alert_1")
+
+    job_queue_high = DummyJobQueue()
+    handlers.evaluate_sugar(2, 9, job_queue_high)
+    with TestSession() as session:
+        alert2 = session.query(Alert).filter_by(user_id=2).first()
+        assert alert2.type == "high"
+    assert job_queue_high.get_jobs_by_name("alert_2")
+
+
+@pytest.mark.asyncio
+async def test_repeat_logic():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    handlers.SessionLocal = TestSession
+    handlers.commit_session = commit_session
+
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.add(Profile(telegram_id=1, low_threshold=4, high_threshold=8))
+        session.commit()
+
+    job_queue = DummyJobQueue()
+    handlers.evaluate_sugar(1, 3, job_queue)
+
+    for i in range(1, 4):
+        context = SimpleNamespace(job=SimpleNamespace(data={"user_id": 1, "count": i}), job_queue=job_queue)
+        await handlers.alert_job(context)
+
+    assert len(job_queue.jobs) == 3
+
+
+@pytest.mark.asyncio
+async def test_normal_reading_resolves_alert():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    handlers.SessionLocal = TestSession
+    handlers.commit_session = commit_session
+
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.add(Profile(telegram_id=1, low_threshold=4, high_threshold=8))
+        session.commit()
+
+    job_queue = DummyJobQueue()
+    handlers.evaluate_sugar(1, 3, job_queue)
+    assert job_queue.jobs
+
+    handlers.evaluate_sugar(1, 5, job_queue)
+    with TestSession() as session:
+        alert = session.query(Alert).filter_by(user_id=1).first()
+        assert alert.resolved
+    assert job_queue.jobs[0].removed


### PR DESCRIPTION
## Summary
- add basic alert handler for sugar threshold monitoring
- test alert scheduling, repeats, and resolution

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6890c75b2e24832a977eb4abd97b0153