### PR TITLE
[db] Add sos_contact to profile

### DIFF
--- a/alembic/versions/6ef15f4d16ef_add_sos_contact_to_profiles.py
+++ b/alembic/versions/6ef15f4d16ef_add_sos_contact_to_profiles.py
@@ -1,0 +1,28 @@
+"""add sos_contact to profiles
+
+Revision ID: 6ef15f4d16ef
+Revises: a64429805715
+Create Date: 2025-08-04 15:02:52.351955
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6ef15f4d16ef'
+down_revision: Union[str, None] = 'a64429805715'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("profiles", sa.Column("sos_contact", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("profiles", "sos_contact")

--- a/diabetes/alert_handlers.py
+++ b/diabetes/alert_handlers.py
@@ -1,6 +1,8 @@
 
 from __future__ import annotations
 
+import datetime
+
 from telegram.ext import ContextTypes
 
 from diabetes.db import SessionLocal, Alert, Profile
@@ -59,4 +61,24 @@ async def alert_job(context: ContextTypes.DEFAULT_TYPE) -> None:
     if count >= MAX_REPEATS:
         return
     schedule_alert(user_id, context.job_queue, count=count + 1)
+
+
+async def alert_stats(update, context) -> None:
+    """Отправить статистику предупреждений за последние 7 дней."""
+    user_id = update.effective_user.id
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    week_ago = now - datetime.timedelta(days=7)
+
+    with SessionLocal() as session:
+        alerts = (
+            session.query(Alert)
+            .filter(Alert.user_id == user_id, Alert.ts >= week_ago)
+            .all()
+        )
+
+    hypo = sum(1 for a in alerts if a.type == "hypo")
+    hyper = sum(1 for a in alerts if a.type == "hyper")
+
+    text = f"За 7\u202Fдн.: гипо\u202F{hypo}, гипер\u202F{hyper}"
+    await update.message.reply_text(text)
 

--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -49,6 +49,7 @@ class Profile(Base):
     target_bg = Column(Float)  # целевой сахар
     low_threshold = Column(Float)  # нижний порог сахара
     high_threshold = Column(Float)  # верхний порог сахара
+    sos_contact = Column(String)  # контакт для экстренной связи
     user = relationship("User")
 
 


### PR DESCRIPTION
## Summary
- add optional `sos_contact` field to `Profile`
- provide Alembic migration to add the column
- implement `alert_stats` handler to report weekly alert counts

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6890cb08c8f4832aa090a4b40dea681b