### PR TITLE
[alerts] notify critical sugar

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -49,6 +49,8 @@ def commit_session(session) -> bool:
         return False
 
 
+
+
 from .onboarding_handlers import (  # noqa: E402
     start_command,
     onboarding_conv,
@@ -73,6 +75,10 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             if not commit_session(session):
                 await query.edit_message_text("⚠️ Не удалось сохранить запись.")
                 return
+        sugar = entry_data.get("sugar_before")
+        if sugar is not None:
+            from .alert_handlers import check_alert
+            await check_alert(update, context, sugar)
         await query.edit_message_text("✅ Запись сохранена в дневник!")
         from . import reminder_handlers
 

--- a/diabetes/utils.py
+++ b/diabetes/utils.py
@@ -1,6 +1,8 @@
 # utils.py
 
+import json
 import re
+from urllib.request import urlopen
 from reportlab.pdfbase.pdfmetrics import stringWidth
 from reportlab.lib.units import mm
 
@@ -15,6 +17,22 @@ def clean_markdown(text: str) -> str:
     text = re.sub(r'^\s*\*\s*', '', text, flags=re.MULTILINE)      # * списки
     text = re.sub(r'`([^`]+)`', r'\1', text)           # `код`
     return text
+
+
+def get_coords_and_link() -> tuple[str, str]:
+    """Return approximate coordinates and Google Maps link based on IP."""
+    try:
+        with urlopen("https://ipinfo.io/json", timeout=5) as resp:
+            data = json.load(resp)
+            loc = data.get("loc")
+            if loc:
+                lat, lon = loc.split(",")
+                coords = f"{lat},{lon}"
+                link = f"https://maps.google.com/?q={lat},{lon}"
+                return coords, link
+    except Exception:  # pragma: no cover - network failures
+        pass
+    return "0.0,0.0", "https://maps.google.com/?q=0.0,0.0"
 
 
 def split_text_by_width(

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -133,6 +133,12 @@ async def test_photo_flow_saves_entry(monkeypatch, tmp_path):
 
     session = DummySession()
     monkeypatch.setattr(common_handlers, "SessionLocal", lambda: session)
+    import diabetes.alert_handlers as alert_handlers
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(alert_handlers, "check_alert", noop)
 
     query = DummyQuery("confirm_entry")
     update_confirm = SimpleNamespace(callback_query=query)


### PR DESCRIPTION
## Summary
- log sugar alerts and notify user & SOS contact after repeated critical readings
- resolve or track active alerts to avoid duplicates
- add simple IP-based location helper

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6890ce0e70ec832a8c9b077d5767a278