### PR TITLE
[handlers] Add profile security menu placeholder

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -300,6 +300,11 @@ def register_handlers(app: Application) -> None:
         )
     )
     app.add_handler(
+        CallbackQueryHandler(
+            profile_handlers.profile_security, pattern="^profile_security$"
+        )
+    )
+    app.add_handler(
         CallbackQueryHandler(profile_handlers.profile_back, pattern="^profile_back$")
     )
     app.add_handler(CallbackQueryHandler(reminder_handlers.reminder_callback, pattern="^remind_"))

--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -174,6 +174,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     keyboard = InlineKeyboardMarkup(
         [
             [InlineKeyboardButton("✏️ Изменить", callback_data="profile_edit")],
+            [InlineKeyboardButton("🔔 Безопасность", callback_data="profile_security")],
             [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
         ]
     )
@@ -192,6 +193,19 @@ async def profile_back(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await query.answer()
     await query.message.delete()
     await query.message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
+
+
+async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Open security settings menu."""
+    query = update.callback_query
+    await query.answer()
+    await query.message.delete()
+    keyboard = InlineKeyboardMarkup(
+        [[InlineKeyboardButton("🔙 Назад", callback_data="profile_back")]]
+    )
+    await query.message.reply_text(
+        "🔐 Настройки безопасности (в разработке)", reply_markup=keyboard
+    )
 
 
 async def profile_edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -411,6 +425,7 @@ __all__ = [
     "profile_view",
     "profile_cancel",
     "profile_back",
+    "profile_security",
     "profile_edit",
     "profile_conv",
 ]


### PR DESCRIPTION
## Summary
- add security button to profile menu
- implement `profile_security` handler opening security settings
- register new callback handler

## Testing
- `ruff check diabetes tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6890d6287214832abfc2d4bbdb32997e