### PR TITLE
[profile] Add SOS alerts toggle and thresholds editor

### DIFF
--- a/alembic/versions/b5a1c2d3e4f6_add_sos_alerts_enabled.py
+++ b/alembic/versions/b5a1c2d3e4f6_add_sos_alerts_enabled.py
@@ -1,0 +1,38 @@
+"""add sos_alerts_enabled to profiles
+
+Revision ID: b5a1c2d3e4f6
+Revises: 6ef15f4d16ef
+Create Date: 2025-08-06 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b5a1c2d3e4f6"
+down_revision: Union[str, None] = "6ef15f4d16ef"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "profiles",
+        sa.Column(
+            "sos_alerts_enabled",
+            sa.Boolean(),
+            server_default=sa.true(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("profiles", "sos_alerts_enabled")
+

--- a/diabetes/alert_handlers.py
+++ b/diabetes/alert_handlers.py
@@ -80,7 +80,7 @@ async def check_alert(update, context: ContextTypes.DEFAULT_TYPE, sugar: float) 
                     f"⚠️ У {first_name} критический сахар {sugar} ммоль/л. {coords} {link}"
                 )
                 await context.bot.send_message(chat_id=user_id, text=msg)
-                if profile.sos_contact:
+                if profile.sos_contact and profile.sos_alerts_enabled:
                     await context.bot.send_message(chat_id=profile.sos_contact, text=msg)
                 for a in alerts:
                     a.resolved = True

--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -301,7 +301,7 @@ def register_handlers(app: Application) -> None:
     )
     app.add_handler(
         CallbackQueryHandler(
-            profile_handlers.profile_security, pattern="^profile_security$"
+            profile_handlers.profile_security, pattern="^profile_security"
         )
     )
     app.add_handler(

--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -50,6 +50,7 @@ class Profile(Base):
     low_threshold = Column(Float)  # нижний порог сахара
     high_threshold = Column(Float)  # верхний порог сахара
     sos_contact = Column(String)  # контакт для экстренной связи
+    sos_alerts_enabled = Column(Boolean, default=True)
     user = relationship("User")
 
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -40,9 +40,9 @@ async def test_threshold_evaluation():
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t1"))
-        session.add(Profile(telegram_id=1, low_threshold=4, high_threshold=8))
+        session.add(Profile(telegram_id=1, low_threshold=4, high_threshold=8, sos_alerts_enabled=True))
         session.add(User(telegram_id=2, thread_id="t2"))
-        session.add(Profile(telegram_id=2, low_threshold=4, high_threshold=8))
+        session.add(Profile(telegram_id=2, low_threshold=4, high_threshold=8, sos_alerts_enabled=True))
         session.commit()
 
     job_queue_low = DummyJobQueue()
@@ -70,7 +70,7 @@ async def test_repeat_logic():
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
-        session.add(Profile(telegram_id=1, low_threshold=4, high_threshold=8))
+        session.add(Profile(telegram_id=1, low_threshold=4, high_threshold=8, sos_alerts_enabled=True))
         session.commit()
 
     job_queue = DummyJobQueue()
@@ -93,7 +93,7 @@ async def test_normal_reading_resolves_alert():
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
-        session.add(Profile(telegram_id=1, low_threshold=4, high_threshold=8))
+        session.add(Profile(telegram_id=1, low_threshold=4, high_threshold=8, sos_alerts_enabled=True))
         session.commit()
 
     job_queue = DummyJobQueue()
@@ -122,6 +122,7 @@ async def test_three_alerts_notify(monkeypatch):
             low_threshold=4,
             high_threshold=8,
             sos_contact="2",
+            sos_alerts_enabled=True,
         ))
         session.commit()
 


### PR DESCRIPTION
## Summary
- add `sos_alerts_enabled` flag to profile model and database
- expose security settings UI with threshold adjust buttons and SOS toggle
- prevent sending SOS alerts when disabled

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6890d7d07a3c832a8562080339f47686