### PR TITLE
[bot] Set bot commands before polling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,8 +3,10 @@
 from diabetes.common_handlers import register_handlers
 from diabetes.db import init_db
 from diabetes.config import LOG_LEVEL, TELEGRAM_TOKEN
+from telegram import BotCommand
 from telegram.ext import ApplicationBuilder
 from sqlalchemy.exc import SQLAlchemyError
+import asyncio
 import logging
 import sys
 
@@ -32,6 +34,21 @@ def main():
 
     app = ApplicationBuilder().token(TELEGRAM_TOKEN).build()
     register_handlers(app)
+
+    commands = [
+        BotCommand("start", "Запустить бота"),
+        BotCommand("menu", "Главное меню"),
+        BotCommand("profile", "Мой профиль"),
+        BotCommand("report", "Отчёт"),
+        BotCommand("sugar", "Расчёт сахара"),
+        BotCommand("gpt", "Чат с GPT"),
+        BotCommand("reminders", "Список напоминаний"),
+        BotCommand("addreminder", "Добавить напоминание"),
+        BotCommand("delreminder", "Удалить напоминание"),
+        BotCommand("help", "Справка"),
+    ]
+    asyncio.run(app.bot.set_my_commands(commands))
+
     app.run_polling()
 
 

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -21,7 +21,13 @@ def test_log_level_debug(monkeypatch):
     # Stub external interactions
     monkeypatch.setattr(bot, "init_db", lambda: None)
 
+    class DummyBot:
+        async def set_my_commands(self, commands):
+            return None
+
     class DummyApp:
+        bot = DummyBot()
+
         def run_polling(self):
             return None
 


### PR DESCRIPTION
## Summary
- set core bot commands, including reminders operations, before polling starts
- adjust debug logging test to account for bot command setup

## Testing
- `ruff check diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_6890f0155b18832aa68b508987e5f530