### PR TITLE
[reminders] Add reminders menu button and handler

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -289,6 +289,11 @@ def register_handlers(app: Application) -> None:
         MessageHandler(filters.Regex("^🕹 Быстрый ввод$"), smart_input_help)
     )
     app.add_handler(
+        MessageHandler(
+            filters.Regex("^⏰ Напоминания$"), reminder_handlers.reminders_list
+        )
+    )
+    app.add_handler(
         MessageHandler(filters.Regex("^ℹ️ Помощь$"), help_command)
     )
     app.add_handler(

--- a/diabetes/ui.py
+++ b/diabetes/ui.py
@@ -30,6 +30,7 @@ menu_keyboard = ReplyKeyboardMarkup(
         [KeyboardButton("💉 Доза инсулина"), KeyboardButton("📊 История")],
         [KeyboardButton("📈 Отчёт"), KeyboardButton("📄 Мой профиль")],
         [KeyboardButton("🕹 Быстрый ввод"), KeyboardButton("ℹ️ Помощь")],
+        [KeyboardButton("⏰ Напоминания")],
     ],
     resize_keyboard=True,
     one_time_keyboard=False,

--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -1,0 +1,27 @@
+import os
+import re
+from telegram.ext import ApplicationBuilder, MessageHandler
+from diabetes.ui import menu_keyboard
+import diabetes.common_handlers as handlers
+import diabetes.reminder_handlers as reminder_handlers
+
+
+def test_reminders_button_matches_regex():
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+    import diabetes.openai_utils as openai_utils  # noqa: F401
+
+    button_texts = [btn.text for row in menu_keyboard.keyboard for btn in row]
+    assert "⏰ Напоминания" in button_texts
+
+    app = ApplicationBuilder().token("TESTTOKEN").build()
+    handlers.register_handlers(app)
+    reminder_handler = next(
+        h
+        for h in app.handlers[0]
+        if isinstance(h, MessageHandler) and h.callback is reminder_handlers.reminders_list
+    )
+    pattern = reminder_handler.filters.pattern.pattern
+    assert pattern == "^⏰ Напоминания$"
+    assert re.fullmatch(pattern, "⏰ Напоминания")
+


### PR DESCRIPTION
## Summary
- add ⏰ Напоминания button to the main menu
- route button presses to reminders list handler
- test that the reminders button matches its regex

## Testing
- `ruff check diabetes tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f1da1e64832a997fa7cf48de2b1c