### PR TITLE
[ci] Run ruff in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
+      - name: Run lint
+        run: ruff check .
       - name: Run tests
         run: |
           set -o pipefail

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,2 +1,2 @@
 line-length = 120
-extend-exclude = ["diabetes/handlers.py"]
+extend-exclude = ["diabetes/handlers.py", "alembic"]


### PR DESCRIPTION
## Summary
- run `ruff check .` during CI
- ignore Alembic directory in ruff config

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890f22bc540832abec23d1dcd8da929