### PR TITLE
[handlers] Document reminder commands in help

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -197,6 +197,9 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "/report - отчёт\n"
         "/sugar - расчёт сахара\n"
         "/gpt - чат с GPT\n"
+        "/reminders - список напоминаний\n"
+        "/addreminder - добавить напоминание\n"
+        "/delreminder - удалить напоминание\n"
         "/cancel - отменить ввод\n"
         "/help - справка\n"
         "/hypoalert - FAQ по гипогликемии\n\n"
@@ -218,6 +221,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "📊 История\n"
         "📈 Отчёт\n"
         "📄 Мой профиль\n"
+        "⏰ Напоминания\n"
         "ℹ️ Помощь"
     )
     await update.message.reply_text(text, reply_markup=menu_keyboard)

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -49,3 +49,20 @@ async def test_help_includes_security_block():
     assert "Напоминания" in text
     assert "/hypoalert" in text
     assert "/profile" in text
+
+
+@pytest.mark.asyncio
+async def test_help_lists_reminder_commands_and_menu_button():
+    """Ensure reminder commands and menu button are documented."""
+
+    message = DummyMessage()
+    update = SimpleNamespace(message=message)
+    context = SimpleNamespace()
+
+    await handlers.help_command(update, context)
+
+    text = message.replies[0]
+    assert "/reminders - список напоминаний\n" in text
+    assert "/addreminder - добавить напоминание\n" in text
+    assert "/delreminder - удалить напоминание\n" in text
+    assert "⏰ Напоминания\n" in text


### PR DESCRIPTION
## Summary
- document `/reminders`, `/addreminder`, `/delreminder` in help text
- list "⏰ Напоминания" among menu buttons
- test that help mentions new reminder commands and button

## Testing
- `pre-commit run --files diabetes/common_handlers.py tests/test_help_command.py`
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6890f3d1a59c832a904b47e78ca72ac5