### PR TITLE
[handlers] Remove duplicate sugar command

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -266,7 +266,6 @@ def register_handlers(app: Application) -> None:
     app.add_handler(dose_handlers.sugar_conv)
     app.add_handler(profile_handlers.profile_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
-    app.add_handler(CommandHandler("sugar", dose_handlers.sugar_start))
     app.add_handler(CommandHandler("cancel", dose_handlers.dose_cancel))
     app.add_handler(CommandHandler("help", help_command))
     app.add_handler(CommandHandler("gpt", dose_handlers.chat_with_gpt))

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -29,8 +29,8 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert dose_handlers.photo_handler in callbacks
     assert dose_handlers.doc_handler in callbacks
     assert dose_handlers.prompt_photo in callbacks
-    assert dose_handlers.prompt_sugar in callbacks
     assert dose_handlers.dose_cancel in callbacks
+    assert dose_handlers.prompt_sugar not in callbacks
     assert callback_router in callbacks
     assert reporting_handlers.report_period_callback in callbacks
     assert profile_handlers.profile_view in callbacks
@@ -121,7 +121,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
         for h in handlers
         if isinstance(h, CommandHandler) and h.callback is dose_handlers.sugar_start
     ]
-    assert sugar_cmd and "sugar" in sugar_cmd[0].commands
+    assert not sugar_cmd
 
     cancel_cmd = [
         h


### PR DESCRIPTION
## Summary
- drop redundant `/sugar` command handler so conversation handles it alone
- adjust tests to ensure sugar conversation is registered and no extra handler remains

## Testing
- `ruff check diabetes tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890f88e1b38832a954139b182c7a14a