### PR TITLE
[reminders] Validate args count when updating

### DIFF
--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -90,6 +90,12 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 return
         else:
             reminder = None
+        if len(args) <= idx + 1:
+            if message:
+                await message.reply_text(
+                    "Формат: /addreminder [id] <type> <time|interval>",
+                )
+            return
         rtype = args[idx]
         val = args[idx + 1]
         if reminder is None:


### PR DESCRIPTION
## Summary
- ensure add_reminder verifies required arguments after optional id
- cover missing-value case for `/addreminder 1 sugar`

## Testing
- `ruff check diabetes tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890fe946588832a89dbb0455c55ec9e