### PR TITLE
[utils] make geolocation lookup async

### DIFF
--- a/diabetes/alert_handlers.py
+++ b/diabetes/alert_handlers.py
@@ -74,7 +74,7 @@ async def check_alert(update, context: ContextTypes.DEFAULT_TYPE, sugar: float) 
                 .all()
             )
             if len(alerts) == 3 and all(a.type == atype for a in alerts):
-                coords, link = get_coords_and_link()
+                coords, link = await get_coords_and_link()
                 first_name = update.effective_user.first_name or ""
                 msg = (
                     f"⚠️ У {first_name} критический сахар {sugar} ммоль/л. {coords} {link}"

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -135,7 +135,10 @@ async def test_three_alerts_notify(monkeypatch):
 
     update = SimpleNamespace(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
     context = SimpleNamespace(bot=DummyBot())
-    monkeypatch.setattr(handlers, "get_coords_and_link", lambda: ("0,0", "link"))
+    async def fake_get_coords_and_link():
+        return ("0,0", "link")
+
+    monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)
 
     for _ in range(2):
         await handlers.check_alert(update, context, 3)

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -71,7 +71,10 @@ async def test_alert_notifies_user_and_contact(test_session, monkeypatch):
     context = SimpleNamespace(bot=SimpleNamespace())
     send_mock = AsyncMock()
     monkeypatch.setattr(context.bot, "send_message", send_mock, raising=False)
-    monkeypatch.setattr(alert_handlers, "get_coords_and_link", lambda: ("0,0", "link"))
+    async def fake_get_coords_and_link():
+        return ("0,0", "link")
+
+    monkeypatch.setattr(alert_handlers, "get_coords_and_link", fake_get_coords_and_link)
 
     for _ in range(3):
         await alert_handlers.check_alert(update_alert, context, 3)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,12 @@
 # test_utils.py
 
+import asyncio
+import io
+import time
+
+import pytest
+
+from diabetes import utils
 from diabetes.utils import clean_markdown, split_text_by_width
 
 def test_clean_markdown():
@@ -16,3 +23,27 @@ def test_split_text_by_width_simple():
     lines = split_text_by_width(text, "DejaVuSans", 12, 50)
     assert isinstance(lines, list)
     assert all(isinstance(line, str) for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_get_coords_and_link_non_blocking(monkeypatch):
+    def slow_urlopen(*args, **kwargs):
+        time.sleep(0.2)
+
+        class Resp:
+            def __enter__(self):
+                return io.StringIO('{"loc": "1,2"}')
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        return Resp()
+
+    monkeypatch.setattr(utils, "urlopen", slow_urlopen)
+
+    start = time.perf_counter()
+    task = asyncio.create_task(utils.get_coords_and_link())
+    await asyncio.sleep(0.05)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 0.2
+    assert await task == ("1,2", "https://maps.google.com/?q=1,2")


### PR DESCRIPTION
## Summary
- make geolocation lookup asynchronous to avoid blocking
- update alert check to await async lookup
- add non-blocking test for geolocation helper

## Testing
- `ruff check diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689100f2cb28832a8ec48da62868c64f