### PR TITLE
[functions] Parse nutrition data on first line

### DIFF
--- a/diabetes/functions.py
+++ b/diabetes/functions.py
@@ -99,9 +99,10 @@ def extract_nutrition_info(text: str) -> tuple[float | None, float | None]:
     """
     if not isinstance(text, str):
         return (None, None)
-    # Если ответ начинается с названия блюда, игнорируем первую строку
+    # Если первая строка не содержит цифр или ключевых слов,
+    # считаем её названием блюда и игнорируем
     lines = text.splitlines()
-    if len(lines) > 1:
+    if len(lines) > 1 and not re.search(r"\d|углевод|[хx][еe]", lines[0], re.IGNORECASE):
         text = "\n".join(lines[1:])
 
     carbs = xe = None

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -126,6 +126,20 @@ def test_extract_nutrition_info_ignores_title_line():
     assert xe == 2
 
 
+def test_extract_nutrition_info_first_line_with_data():
+    text = "Углеводы: 25 г\nХЕ: 2"
+    carbs, xe = extract_nutrition_info(text)
+    assert carbs == 25
+    assert xe == 2
+
+
+def test_extract_nutrition_info_first_line_xe_only():
+    text = "ХЕ: 3\nПрочее"
+    carbs, xe = extract_nutrition_info(text)
+    assert carbs is None
+    assert xe == 3
+
+
 def test_extract_nutrition_info_non_string():
     assert extract_nutrition_info(123) == (None, None)
 


### PR DESCRIPTION
## Summary
- avoid dropping first line when it contains nutrition data
- cover parsing when carbs or XE are in the first line

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6891030bb23c832ab083e937586bb8f3