### PR TITLE
[config] Guard dotenv loading

### DIFF
--- a/diabetes/config.py
+++ b/diabetes/config.py
@@ -6,7 +6,8 @@ import os
 from dotenv import load_dotenv
 
 
-load_dotenv()  # Загрузка переменных из .env файла
+if not os.getenv("SKIP_DOTENV"):
+    load_dotenv()  # Загрузка переменных из .env файла
 
 
 def _read_log_level() -> int:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,8 +19,10 @@ def test_import_config_without_db_password(monkeypatch):
 
 def test_init_db_raises_when_no_password(monkeypatch):
     monkeypatch.delenv("DB_PASSWORD", raising=False)
-    _reload("diabetes.config")
+    monkeypatch.setenv("SKIP_DOTENV", "1")
+    config = _reload("diabetes.config")
     db = _reload("diabetes.db")
+    assert config.DB_PASSWORD is None
     with pytest.raises(ValueError):
         db.init_db()
 


### PR DESCRIPTION
## Summary
- Guard dotenv loading behind SKIP_DOTENV so environment variables can opt out
- Skip dotenv in tests and verify db.init_db raises ValueError without DB_PASSWORD

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6891037cd0dc832aa1d3311f9e8ea237