### PR TITLE
[bot] Make main async

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,14 +6,14 @@ from diabetes.config import LOG_LEVEL, TELEGRAM_TOKEN
 from telegram import BotCommand
 from telegram.ext import ApplicationBuilder
 from sqlalchemy.exc import SQLAlchemyError
-import asyncio
 import logging
 import sys
+import asyncio
 
 logger = logging.getLogger(__name__)
 
 
-def main():
+async def main():
     logging.basicConfig(
         level=LOG_LEVEL,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -47,10 +47,10 @@ def main():
         BotCommand("delreminder", "Удалить напоминание"),
         BotCommand("help", "Справка"),
     ]
-    asyncio.run(app.bot.set_my_commands(commands))
+    await app.bot.set_my_commands(commands)
 
-    app.run_polling()
+    await app.run_polling()
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/tests/test_bot_db_error.py
+++ b/tests/test_bot_db_error.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
+import asyncio
 
 import bot
 
@@ -15,7 +16,7 @@ def test_main_logs_db_error(monkeypatch, caplog):
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(SystemExit) as exc:
-            bot.main()
+            asyncio.run(bot.main())
 
     assert exc.value.code == 1
     assert any(

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -3,6 +3,7 @@
 import importlib
 import logging
 import sys
+import asyncio
 
 
 def test_log_level_debug(monkeypatch):
@@ -28,7 +29,7 @@ def test_log_level_debug(monkeypatch):
     class DummyApp:
         bot = DummyBot()
 
-        def run_polling(self):
+        async def run_polling(self):
             return None
 
     class DummyBuilder:
@@ -48,7 +49,7 @@ def test_log_level_debug(monkeypatch):
     root.handlers.clear()
 
     try:
-        bot.main()
+        asyncio.run(bot.main())
         assert root.level == logging.DEBUG
     finally:
         root.handlers[:] = previous_handlers


### PR DESCRIPTION
## Summary
- make bot.main asynchronous and set commands via await
- run bot with asyncio.run and await run_polling
- update tests for async main

## Testing
- `pytest -q`
- `ruff check diabetes tests`


------
https://chatgpt.com/codex/tasks/task_e_689104b93bf4832a8139402e35a4e3ab