### PR TITLE
[db] Recreate engine when connection URL changes

### DIFF
--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -105,17 +105,17 @@ def init_db() -> None:
 
     if not config.DB_PASSWORD:
         raise ValueError("DB_PASSWORD environment variable must be set")
+    database_url = URL.create(
+        "postgresql",
+        username=DB_USER,
+        password=config.DB_PASSWORD,
+        host=DB_HOST,
+        port=int(DB_PORT),
+        database=DB_NAME,
+    )
 
     global engine
-    if engine is None or engine.url.password != config.DB_PASSWORD:
-        database_url = URL.create(
-            "postgresql",
-            username=DB_USER,
-            password=config.DB_PASSWORD,
-            host=DB_HOST,
-            port=int(DB_PORT),
-            database=DB_NAME,
-        )
+    if engine is None or engine.url != database_url:
         if engine is not None:
             engine.dispose()
         engine = create_engine(database_url)


### PR DESCRIPTION
## Summary
- avoid stale connections by rebuilding the engine when any part of the database URL changes
- test that changing DB host or name triggers engine recreation

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68910584d388832a9fdbf5fc6cefe0f5