### PR TITLE
[deps] Bump reportlab to 4.4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pytest-asyncio==1.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 python-telegram-bot==20.4
-reportlab==3.6.12
+reportlab==4.4.3
 six==1.17.0
 sniffio==1.3.1
 SQLAlchemy==2.0.42


### PR DESCRIPTION
## Summary
- upgrade reportlab dependency to 4.4.3

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68910bacb69c832a921da4abbc5f676a