### PR TITLE
bot: switch to synchronous entry point

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,14 +6,15 @@ from diabetes.config import LOG_LEVEL, TELEGRAM_TOKEN
 from telegram import BotCommand
 from telegram.ext import ApplicationBuilder
 from sqlalchemy.exc import SQLAlchemyError
+import asyncio
 import logging
 import sys
-import asyncio
 
 logger = logging.getLogger(__name__)
 
 
-async def main():
+def main() -> None:
+    """Configure and start the bot."""
     logging.basicConfig(
         level=LOG_LEVEL,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -47,10 +48,10 @@ async def main():
         BotCommand("delreminder", "Удалить напоминание"),
         BotCommand("help", "Справка"),
     ]
-    await app.bot.set_my_commands(commands)
+    asyncio.run(app.bot.set_my_commands(commands))
 
-    await app.run_polling()
+    app.run_polling()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -3,7 +3,6 @@
 import importlib
 import logging
 import sys
-import asyncio
 
 
 def test_log_level_debug(monkeypatch):
@@ -29,7 +28,7 @@ def test_log_level_debug(monkeypatch):
     class DummyApp:
         bot = DummyBot()
 
-        async def run_polling(self):
+        def run_polling(self):
             return None
 
     class DummyBuilder:
@@ -49,7 +48,7 @@ def test_log_level_debug(monkeypatch):
     root.handlers.clear()
 
     try:
-        asyncio.run(bot.main())
+        bot.main()
         assert root.level == logging.DEBUG
     finally:
         root.handlers[:] = previous_handlers


### PR DESCRIPTION
## Summary
- convert bot startup to a synchronous entry point, setting commands before polling
- update debug logging test for synchronous main

## Testing
- `ruff check bot.py diabetes tests`
- `pytest tests/`
- `python bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68910ef53eb4832ab177155179f84403