### PR TITLE
[bot] Convert main to async and use asyncio.run

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,7 @@ import sys
 logger = logging.getLogger(__name__)
 
 
-def main() -> None:
+async def main() -> None:
     """Configure and start the bot."""
     logging.basicConfig(
         level=LOG_LEVEL,
@@ -48,10 +48,9 @@ def main() -> None:
         BotCommand("delreminder", "Удалить напоминание"),
         BotCommand("help", "Справка"),
     ]
-    asyncio.run(app.bot.set_my_commands(commands))
+    await app.bot.set_my_commands(commands)
 
-    app.run_polling()
-
+    await app.run_polling()
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -3,6 +3,7 @@
 import importlib
 import logging
 import sys
+import asyncio
 
 
 def test_log_level_debug(monkeypatch):
@@ -28,7 +29,7 @@ def test_log_level_debug(monkeypatch):
     class DummyApp:
         bot = DummyBot()
 
-        def run_polling(self):
+        async def run_polling(self):
             return None
 
     class DummyBuilder:
@@ -48,7 +49,7 @@ def test_log_level_debug(monkeypatch):
     root.handlers.clear()
 
     try:
-        bot.main()
+        asyncio.run(bot.main())
         assert root.level == logging.DEBUG
     finally:
         root.handlers[:] = previous_handlers


### PR DESCRIPTION
## Summary
- make `bot.main` an async coroutine and await command setup and polling
- update debug logging test to use the async bot entry point

## Testing
- `ruff check bot.py diabetes tests`
- `pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_68911ae58578832ab63cd80caff1246c