### PR TITLE
[gpt_client] Refine file upload error handling

### DIFF
--- a/diabetes/gpt_client.py
+++ b/diabetes/gpt_client.py
@@ -68,8 +68,11 @@ def send_message(
                 {"type": "text", "text": content or "Что изображено на фото?"},
             ]
             upload_succeeded = True
-        except Exception as e:
-            logging.exception("[OpenAI] Failed to upload %s: %s", image_path, e)
+        except OSError as exc:
+            logging.exception("[OpenAI] Failed to read %s: %s", image_path, exc)
+            raise
+        except OpenAIError as exc:
+            logging.exception("[OpenAI] Failed to upload %s: %s", image_path, exc)
             raise
         finally:
             if upload_succeeded and not keep_image:


### PR DESCRIPTION
## Summary
- handle file read and OpenAI API errors separately during image upload

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68918428ee98832abd2c1b47a7a214cc