### PR TITLE
[bot] Use run_polling to keep bot running

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,4 @@
-# bot.py
+"""Bot entry point and configuration."""
 
 from diabetes.common_handlers import register_handlers
 from diabetes.db import init_db
@@ -13,8 +13,8 @@ import sys
 logger = logging.getLogger(__name__)
 
 
-async def main() -> None:
-    """Configure and start the bot."""
+def main() -> None:
+    """Configure and run the bot."""
     logging.basicConfig(
         level=LOG_LEVEL,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -24,7 +24,7 @@ async def main() -> None:
     BOT_TOKEN = TELEGRAM_TOKEN
     if not BOT_TOKEN:
         logger.error(
-            "BOT_TOKEN is not set. Please provide the environment variable."
+            "BOT_TOKEN is not set. Please provide the environment variable.",
         )
         sys.exit(1)
 
@@ -49,15 +49,10 @@ async def main() -> None:
         BotCommand("delreminder", "Удалить напоминание"),
         BotCommand("help", "Справка"),
     ]
-    await application.bot.set_my_commands(commands)
+    asyncio.run(application.bot.set_my_commands(commands))
 
-    await application.initialize()
-    await application.start()
-    await application.updater.start_polling()
-    await application.updater.idle()
+    application.run_polling()
 
-    await application.stop()
-    await application.shutdown()
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -3,7 +3,6 @@
 import importlib
 import logging
 import sys
-import asyncio
 
 
 def test_log_level_debug(monkeypatch):
@@ -26,27 +25,10 @@ def test_log_level_debug(monkeypatch):
         async def set_my_commands(self, commands):
             return None
 
-    class DummyUpdater:
-        async def start_polling(self):
-            return None
-
-        async def idle(self):
-            return None
-
     class DummyApp:
         bot = DummyBot()
-        updater = DummyUpdater()
 
-        async def initialize(self):
-            return None
-
-        async def start(self):
-            return None
-
-        async def stop(self):
-            return None
-
-        async def shutdown(self):
+        def run_polling(self):
             return None
 
     class DummyBuilder:
@@ -71,7 +53,7 @@ def test_log_level_debug(monkeypatch):
     root.handlers.clear()
 
     try:
-        asyncio.run(bot.main())
+        bot.main()
         assert root.level == logging.DEBUG
     finally:
         root.handlers[:] = previous_handlers


### PR DESCRIPTION
## Summary
- switch bot startup to `Application.run_polling` and set commands via `asyncio.run`
- adjust debug logging test to match new startup method

## Testing
- `ruff check diabetes tests`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_6891867782f0832a8878bf804dd2fc64