### PR TITLE
[reminders] Validate numeric reminder values

### DIFF
--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -120,11 +120,21 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             if ":" in val:
                 reminder.time = val
             else:
-                reminder.interval_hours = int(val)
+                try:
+                    reminder.interval_hours = int(val)
+                except ValueError:
+                    if message:
+                        await message.reply_text("Интервал должен быть числом.")
+                    return
         elif rtype in {"long_insulin", "medicine"}:
             reminder.time = val
         elif rtype == "xe_after":
-            reminder.minutes_after = int(val)
+            try:
+                reminder.minutes_after = int(val)
+            except ValueError:
+                if message:
+                    await message.reply_text("Значение должно быть числом.")
+                return
         commit_session(session)
         rid = reminder.id
     for job in context.job_queue.get_jobs_by_name(f"reminder_{rid}"):


### PR DESCRIPTION
## Summary
- ensure reminder interval and delay values are numeric before saving

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6891888c1f98832ab0d4ef159a7dccdb