### PR TITLE
[bot] Run bot setup in single async coroutine

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,7 @@ import sys
 logger = logging.getLogger(__name__)
 
 
-def main() -> None:
+async def main() -> None:
     """Configure and run the bot."""
     logging.basicConfig(
         level=LOG_LEVEL,
@@ -49,10 +49,10 @@ def main() -> None:
         BotCommand("delreminder", "Удалить напоминание"),
         BotCommand("help", "Справка"),
     ]
-    asyncio.run(application.bot.set_my_commands(commands))
+    await application.bot.set_my_commands(commands)
 
-    application.run_polling()
+    await application.run_polling()
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -3,6 +3,7 @@
 import importlib
 import logging
 import sys
+import asyncio
 
 
 def test_log_level_debug(monkeypatch):
@@ -28,7 +29,7 @@ def test_log_level_debug(monkeypatch):
     class DummyApp:
         bot = DummyBot()
 
-        def run_polling(self):
+        async def run_polling(self):
             return None
 
     class DummyBuilder:
@@ -53,7 +54,7 @@ def test_log_level_debug(monkeypatch):
     root.handlers.clear()
 
     try:
-        bot.main()
+        asyncio.run(bot.main())
         assert root.level == logging.DEBUG
     finally:
         root.handlers[:] = previous_handlers


### PR DESCRIPTION
## Summary
- make bot.main an async coroutine and await bot command setup and polling
- adjust debug logging test to handle async main

## Testing
- `ruff check bot.py diabetes tests`
- `pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_68918a19b218832aaa89e38590122cf4