### PR TITLE
[reminders] Validate reminder ID on deletion

### DIFF
--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -151,7 +151,12 @@ async def delete_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         if message:
             await message.reply_text("Укажите ID: /delreminder <id>")
         return
-    rid = int(args[0])
+    try:
+        rid = int(args[0])
+    except ValueError:
+        if message:
+            await message.reply_text("ID должен быть числом: /delreminder <id>")
+        return
     with SessionLocal() as session:
         rem = session.get(Reminder, rid)
         if not rem:


### PR DESCRIPTION
## Summary
- handle non-numeric reminder IDs in delete handler

## Testing
- `ruff check diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68918af78bb8832aa95daca04c423f26