### PR TITLE
[handlers] Safeguard freeform fields parsing

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -506,7 +506,12 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
         return
 
-    fields = parsed["fields"]
+    fields = parsed.get("fields")
+    if not isinstance(fields, dict):
+        await update.message.reply_text(
+            "Не удалось распознать данные, попробуйте ещё раз."
+        )
+        return
     entry_date = parsed.get("entry_date")
     time_str = parsed.get("time")
 


### PR DESCRIPTION
## Summary
- ensure dose handlers handle missing or invalid fields safely

## Testing
- `ruff check diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68918c29065c832aa2faa40bbed1ab2e