### PR TITLE
[alerts] ignore phone sos contacts

### DIFF
--- a/diabetes/sos_handlers.py
+++ b/diabetes/sos_handlers.py
@@ -25,17 +25,16 @@ async def sos_contact_start(
 ) -> int:
     """Prompt user to enter emergency contact."""
     await update.message.reply_text(
-        "Введите контакт в Telegram (@username) или телефон.",
+        "Введите контакт в Telegram (@username). Телефоны не поддерживаются.",
         reply_markup=back_keyboard,
     )
     return SOS_CONTACT
 
 
 def _is_valid_contact(text: str) -> bool:
-    """Validate telegram username or phone number."""
+    """Validate telegram username."""
     username = re.fullmatch(r"@\w{5,32}", text)
-    phone = re.fullmatch(r"\+?\d{5,15}", text)
-    return bool(username or phone)
+    return bool(username)
 
 
 async def sos_contact_save(
@@ -45,7 +44,7 @@ async def sos_contact_save(
     contact = update.message.text.strip()
     if not _is_valid_contact(contact):
         await update.message.reply_text(
-            "❗ Укажите @username или телефон в международном формате.",
+            "❗ Укажите @username. Телефоны не поддерживаются.",
             reply_markup=back_keyboard,
         )
         return SOS_CONTACT

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -121,7 +121,7 @@ async def test_three_alerts_notify(monkeypatch):
             telegram_id=1,
             low_threshold=4,
             high_threshold=8,
-            sos_contact="2",
+            sos_contact="@alice",
             sos_alerts_enabled=True,
         ))
         session.commit()
@@ -146,7 +146,7 @@ async def test_three_alerts_notify(monkeypatch):
     await handlers.check_alert(update, context, 3)
     assert len(context.bot.sent) == 2
     assert context.bot.sent[0][0] == 1
-    assert context.bot.sent[1][0] == "2"
+    assert context.bot.sent[1][0] == "@alice"
     with TestSession() as session:
         alerts = session.query(Alert).all()
         assert all(a.resolved for a in alerts)

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -84,3 +84,37 @@ async def test_alert_notifies_user_and_contact(test_session, monkeypatch):
         call(chat_id=1, text=msg),
         call(chat_id="@alice", text=msg),
     ]
+
+
+@pytest.mark.asyncio
+async def test_alert_skips_phone_contact(test_session, monkeypatch):
+    with test_session() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.add(
+            Profile(
+                telegram_id=1,
+                low_threshold=4,
+                high_threshold=8,
+                sos_contact="+123",
+                sos_alerts_enabled=True,
+            )
+        )
+        session.commit()
+
+    update_alert = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1, first_name="Ivan")
+    )
+    context = SimpleNamespace(bot=SimpleNamespace())
+    send_mock = AsyncMock()
+    monkeypatch.setattr(context.bot, "send_message", send_mock, raising=False)
+
+    async def fake_get_coords_and_link():
+        return ("0,0", "link")
+
+    monkeypatch.setattr(alert_handlers, "get_coords_and_link", fake_get_coords_and_link)
+
+    for _ in range(3):
+        await alert_handlers.check_alert(update_alert, context, 3)
+
+    msg = "⚠️ У Ivan критический сахар 3 ммоль/л. 0,0 link"
+    assert send_mock.await_args_list == [call(chat_id=1, text=msg)]


### PR DESCRIPTION
## Summary
- log and skip SOS contacts that are phone numbers; send only to @usernames
- restrict SOS contact input to telegram usernames
- add tests for phone contacts being ignored and update existing alert tests

## Testing
- `ruff check diabetes tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689190087740832a9c0b1cf516f21cfa