### PR TITLE
[reminders] Handle add reminder commit failure

### DIFF
--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -135,7 +135,10 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 if message:
                     await message.reply_text("Значение должно быть числом.")
                 return
-        commit_session(session)
+        if not commit_session(session):
+            if message:
+                await message.reply_text("⚠️ Не удалось сохранить напоминание.")
+            return
         rid = reminder.id
     for job in context.job_queue.get_jobs_by_name(f"reminder_{rid}"):
         job.schedule_removal()


### PR DESCRIPTION
## Summary
- Check database commit result when adding reminders
- Inform user on failed reminder save without scheduling reminder
- Cover commit failure path with unit test

## Testing
- `ruff check diabetes tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6891928bf850832a96eec74f75c85367