### PR TITLE
[common_handlers] Use job_queue property

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -326,12 +326,9 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CallbackQueryHandler(reminder_handlers.reminder_callback, pattern="^remind_"))
     app.add_handler(CallbackQueryHandler(callback_router))
 
-    try:  # pragma: no cover - best effort scheduling
-        job_queue = getattr(app, "_job_queue", None)
-        if job_queue:
-            reminder_handlers.schedule_all(job_queue)
-    except Exception:  # pragma: no cover
-        logger.exception("Failed to schedule reminders")
+    job_queue = app.job_queue
+    if job_queue:
+        reminder_handlers.schedule_all(job_queue)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Replace getattr on _job_queue with direct app.job_queue access in register_handlers
- Drop try/except wrapper around job queue scheduling

## Testing
- `ruff check diabetes tests`
- `pytest tests/test_register_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_6891980e9fb4832ab7f126e946164068