### PR TITLE
[alerts] Use hypo/hyper alert types

### DIFF
--- a/diabetes/alert_handlers.py
+++ b/diabetes/alert_handlers.py
@@ -37,7 +37,7 @@ def evaluate_sugar(user_id: int, sugar: float, job_queue) -> None:
         )
 
         if (low is not None and sugar < low) or (high is not None and sugar > high):
-            atype = "low" if low is not None and sugar < low else "high"
+            atype = "hypo" if low is not None and sugar < low else "hyper"
             alert = Alert(user_id=user_id, sugar=sugar, type=atype)
             session.add(alert)
             commit_session(session)

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -49,14 +49,14 @@ async def test_threshold_evaluation():
     handlers.evaluate_sugar(1, 3, job_queue_low)
     with TestSession() as session:
         alert = session.query(Alert).filter_by(user_id=1).first()
-        assert alert.type == "low"
+        assert alert.type == "hypo"
     assert job_queue_low.get_jobs_by_name("alert_1")
 
     job_queue_high = DummyJobQueue()
     handlers.evaluate_sugar(2, 9, job_queue_high)
     with TestSession() as session:
         alert2 = session.query(Alert).filter_by(user_id=2).first()
-        assert alert2.type == "high"
+        assert alert2.type == "hyper"
     assert job_queue_high.get_jobs_by_name("alert_2")
 
 


### PR DESCRIPTION
## Summary
- use "hypo" and "hyper" for alert types in sugar evaluation
- adjust alert tests to match new alert type names

## Testing
- `ruff check diabetes tests`
- `pytest` *(fails: ValueError: a coroutine was expected, got None)*

------
https://chatgpt.com/codex/tasks/task_e_6891a0143468832aac561153f131ed56