### PR TITLE
[functions] Fix calc_bolus docstring example

### DIFF
--- a/diabetes/functions.py
+++ b/diabetes/functions.py
@@ -57,7 +57,7 @@ def calc_bolus(carbs_g: float, current_bg: float, profile: PatientProfile) -> fl
     Examples:
         >>> profile = PatientProfile(icr=10, cf=50, target_bg=5.5)
         >>> calc_bolus(60, 7.0, profile)
-        6.1
+        6.0
     """
     if profile.icr <= 0:
         raise ValueError("Profile icr must be greater than 0")


### PR DESCRIPTION
## Summary
- correct calc_bolus docstring example to reflect actual rounded result

## Testing
- `ruff check diabetes tests`
- `pytest tests/test_functions.py`
- `pytest tests` *(fails: tests/test_bot_debug_logging.py::test_log_level_debug - ValueError: a coroutine was expected, got None)*

------
https://chatgpt.com/codex/tasks/task_e_6891a21cc794832a9e28aad2f7cc859f