### PR TITLE
[handlers] Annotate CallbackQuery return type and fix debug logging test

### DIFF
--- a/diabetes/callbackquery_no_warn_handler.py
+++ b/diabetes/callbackquery_no_warn_handler.py
@@ -1,7 +1,7 @@
 import re
 from typing import Optional
 
-from telegram import Update
+from telegram import CallbackQuery, Update
 from telegram.ext import BaseHandler
 
 
@@ -12,7 +12,7 @@ class CallbackQueryNoWarnHandler(BaseHandler):
         super().__init__(callback)
         self.pattern: Optional[re.Pattern[str]] = re.compile(pattern) if pattern else None
 
-    def check_update(self, update: object) -> Optional[Update]:
+    def check_update(self, update: object) -> Optional[CallbackQuery]:
         if isinstance(update, Update) and update.callback_query:
             data = update.callback_query.data or ""
             if self.pattern is None or self.pattern.match(data):

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -3,7 +3,6 @@
 import importlib
 import logging
 import sys
-import asyncio
 
 
 def test_log_level_debug(monkeypatch):
@@ -23,13 +22,13 @@ def test_log_level_debug(monkeypatch):
     monkeypatch.setattr(bot, "init_db", lambda: None)
 
     class DummyBot:
-        async def set_my_commands(self, commands):
+        def set_my_commands(self, commands):
             return None
 
     class DummyApp:
         bot = DummyBot()
 
-        async def run_polling(self):
+        def run_polling(self):
             return None
 
     class DummyBuilder:
@@ -54,7 +53,7 @@ def test_log_level_debug(monkeypatch):
     root.handlers.clear()
 
     try:
-        asyncio.run(bot.main())
+        bot.main()
         assert root.level == logging.DEBUG
     finally:
         root.handlers[:] = previous_handlers


### PR DESCRIPTION
## Summary
- use CallbackQuery as return type for CallbackQueryNoWarnHandler.check_update
- adjust debug logging test to work with synchronous main

## Testing
- `ruff check diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_6891bbd7d4fc832a8fa5d19e3af5612c