### PR TITLE
[dose] handle missing carb data in sugar step

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -191,6 +191,13 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     entry["sugar_before"] = sugar
     xe = entry.get("xe")
     carbs_g = entry.get("carbs_g")
+    if carbs_g is None and xe is None:
+        await update.message.reply_text(
+            "Не указаны углеводы или ХЕ. Расчёт невозможен.",
+            reply_markup=menu_keyboard,
+        )
+        context.user_data.pop("pending_entry", None)
+        return ConversationHandler.END
     if carbs_g is None and xe is not None:
         carbs_g = xe * 12
         entry["carbs_g"] = carbs_g

--- a/tests/test_dose_sugar_missing.py
+++ b/tests/test_dose_sugar_missing.py
@@ -1,0 +1,39 @@
+import datetime
+from types import SimpleNamespace
+import os
+
+import pytest
+from telegram.ext import ConversationHandler
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+import diabetes.openai_utils as openai_utils  # noqa: F401
+from diabetes import dose_handlers
+
+
+class DummyMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.replies: list[str] = []
+        self.kwargs: list[dict] = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_dose_sugar_requires_carbs_or_xe():
+    entry = {
+        "telegram_id": 1,
+        "event_time": datetime.datetime.now(datetime.timezone.utc),
+    }
+    message = DummyMessage("5.5")
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={"pending_entry": entry})
+
+    result = await dose_handlers.dose_sugar(update, context)
+
+    assert result == ConversationHandler.END
+    assert message.replies and "углев" in message.replies[0].lower()
+    assert context.user_data == {}


### PR DESCRIPTION
## Summary
- ensure `dose_sugar` stops when neither carbs nor XE are provided
- add regression test for missing carb/XE scenario

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6891c7d98718832a9ec5f7ec63985041