### PR TITLE
[handlers] calculate dose on freeform sugar input

### DIFF
--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -48,6 +48,17 @@ async def test_freeform_handler_adds_sugar_to_photo_entry():
         "sugar_before": None,
         "photo_path": "photos/img.jpg",
     }
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, model, user_id):
+            return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
+
+    handlers.SessionLocal = lambda: DummySession()
     message = DummyMessage("5,6")
     update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     context = SimpleNamespace(user_data={"pending_entry": entry})


### PR DESCRIPTION
## Summary
- compute bolus in freeform sugar handler when carbs or XE provided
- test sugar addition for photo entries and pending entries with mocked DB profiles

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6891eae2d8c0832a99de30bb1029d1cc