### PR TITLE
tests: verify dose after photo and sugar

### DIFF
--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -6,7 +6,8 @@ import diabetes.dose_handlers as handlers
 
 
 class DummyMessage:
-    def __init__(self, photo=None):
+    def __init__(self, text=None, photo=None):
+        self.text = text
         self.photo = photo
         self.texts = []
 
@@ -154,3 +155,77 @@ async def test_photo_handler_preserves_file(monkeypatch, tmp_path):
     assert call["keep_image"] is True
     assert Path(call["image_path"]).exists()
     assert result == handlers.PHOTO_SUGAR
+
+
+@pytest.mark.asyncio
+async def test_photo_then_freeform_calculates_dose(monkeypatch, tmp_path):
+    """photo_handler + freeform_handler produce dose in reply and context."""
+
+    class DummyPhoto:
+        file_id = "fid"
+        file_unique_id = "uid"
+
+    class DummyFile:
+        async def download_to_drive(self, path):
+            Path(path).write_bytes(b"img")
+
+    async def fake_get_file(file_id):
+        return DummyFile()
+
+    monkeypatch.chdir(tmp_path)
+    dummy_bot = SimpleNamespace(get_file=fake_get_file)
+
+    class Run:
+        status = "completed"
+        thread_id = "tid"
+        id = "runid"
+
+    def fake_send_message(**kwargs):
+        return Run()
+
+    class DummyClient:
+        beta = SimpleNamespace(
+            threads=SimpleNamespace(
+                runs=SimpleNamespace(retrieve=lambda thread_id, run_id: Run()),
+                messages=SimpleNamespace(list=lambda thread_id: SimpleNamespace(data=[])),
+            )
+        )
+
+    monkeypatch.setattr(handlers, "send_message", fake_send_message)
+    monkeypatch.setattr(handlers, "_get_client", lambda: DummyClient())
+    monkeypatch.setattr(handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
+    monkeypatch.setattr(handlers, "menu_keyboard", None)
+    monkeypatch.setattr(handlers, "confirm_keyboard", lambda: None)
+
+    photo_msg = DummyMessage(photo=[DummyPhoto()])
+    update_photo = SimpleNamespace(
+        message=photo_msg, effective_user=SimpleNamespace(id=1)
+    )
+    context = SimpleNamespace(bot=dummy_bot, user_data={"thread_id": "tid"})
+
+    await handlers.photo_handler(update_photo, context)
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, model, user_id):
+            return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
+
+    handlers.SessionLocal = lambda: DummySession()
+
+    sugar_msg = DummyMessage(text="5")
+    update_sugar = SimpleNamespace(
+        message=sugar_msg, effective_user=SimpleNamespace(id=1)
+    )
+
+    await handlers.freeform_handler(update_sugar, context)
+
+    reply = sugar_msg.texts[0]
+    assert "Углеводы: 10.0 г" in reply
+    assert "Сахар: 5.0 ммоль/л" in reply
+    assert "Ваша доза: 1.0 Ед" in reply
+    assert "dose" in context.user_data["pending_entry"]


### PR DESCRIPTION
## Summary
- add integration test chaining photo_handler and freeform_handler

## Testing
- `ruff check tests/test_handlers_doc.py`
- `pytest tests/test_handlers_doc.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891ee7572e8832a9128c10394a800e4