### PR TITLE
[bot] Use post_init hook for setting bot commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -50,8 +50,10 @@ def main() -> None:
         BotCommand("delreminder", "Удалить напоминание"),
         BotCommand("help", "Справка"),
     ]
-    # Синхронный вызов, не await!
-    application.bot.set_my_commands(commands)
+    async def post_init(app: Application) -> None:
+        await app.bot.set_my_commands(commands)
+
+    application.post_init.append(post_init)
     application.run_polling()
 
 if __name__ == "__main__":

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -27,6 +27,7 @@ def test_log_level_debug(monkeypatch):
 
     class DummyApp:
         bot = DummyBot()
+        post_init = []
 
         def run_polling(self):
             return None


### PR DESCRIPTION
## Summary
- set bot commands via async `post_init` hook
- adjust debug logging test for new hook

## Testing
- `ruff check diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_6891fbcd3a10832a8c656a66308a9376