### PR TITLE
[onboarding] Use context manager for demo photo

### DIFF
--- a/diabetes/onboarding_handlers.py
+++ b/diabetes/onboarding_handlers.py
@@ -180,11 +180,12 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     keyboard = InlineKeyboardMarkup(
         [[InlineKeyboardButton("Далее", callback_data="onb_next")]]
     )
-    await update.message.reply_photo(
-        photo=open("assets/demo.jpg", "rb"),
-        caption="2/3. Вот пример распознавания еды.",
-        reply_markup=keyboard,
-    )
+    with open("assets/demo.jpg", "rb") as photo:
+        await update.message.reply_photo(
+            photo=photo,
+            caption="2/3. Вот пример распознавания еды.",
+            reply_markup=keyboard,
+        )
     return ONB_DEMO
 
 


### PR DESCRIPTION
## Summary
- open demo photo with context manager in onboarding target handler

## Testing
- `ruff check diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_6891fd664a04832a8fb7c39db99a9ff9