### PR TITLE
[handlers] prioritize profile over sugar

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -50,9 +50,8 @@ def main() -> None:
     async def post_init(app: Application) -> None:
         await app.bot.set_my_commands(commands)
 
-    application = (
-        Application.builder().token(BOT_TOKEN).post_init(post_init).build()
-    )
+    application = Application.builder().token(BOT_TOKEN).build()
+    application.post_init.append(post_init)
     register_handlers(application)
     application.run_polling()
 

--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -270,8 +270,10 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("menu", menu_command))
     app.add_handler(CommandHandler("report", reporting_handlers.report_request))
     app.add_handler(dose_handlers.dose_conv)
-    app.add_handler(dose_handlers.sugar_conv)
+    # Register profile conversation before sugar conversation so that numeric
+    # inputs for profile aren't captured by sugar logging
     app.add_handler(profile_handlers.profile_conv)
+    app.add_handler(dose_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(CommandHandler("cancel", dose_handlers.dose_cancel))
     app.add_handler(CommandHandler("help", help_command))

--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -32,6 +32,16 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
     args = context.args
 
+    # Ensure no pending sugar logging conversation captures profile input
+    from .dose_handlers import sugar_conv
+
+    try:  # update may lack chat info in some testing scenarios
+        key = sugar_conv._get_key(update)
+    except AttributeError:
+        key = None
+    if key is not None:
+        sugar_conv._update_state(ConversationHandler.END, key)
+
     help_text = (
         "❗ Формат команды:\n"
         "/profile <ИКХ г/ед.> <КЧ ммоль/л> <целевой ммоль/л> <низкий ммоль/л> <высокий ммоль/л>\n"

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -1,0 +1,67 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+import diabetes.openai_utils as openai_utils  # noqa: F401
+from diabetes import dose_handlers, profile_handlers
+from diabetes.db import Base, Entry, User
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+class DummyMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.replies: list[str] = []
+        self.kwargs: list[dict] = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_profile_input_not_logged_as_sugar(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    monkeypatch.setattr(profile_handlers, "SessionLocal", TestSession)
+    monkeypatch.setattr(dose_handlers, "SessionLocal", TestSession)
+
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.commit()
+
+    # Start sugar conversation
+    sugar_msg = DummyMessage("/sugar")
+    sugar_update = SimpleNamespace(message=sugar_msg, effective_user=SimpleNamespace(id=1), effective_chat=SimpleNamespace(id=1))
+    sugar_context = SimpleNamespace(user_data={})
+    state = await dose_handlers.sugar_start(sugar_update, sugar_context)
+    dose_handlers.sugar_conv._update_state(state, dose_handlers.sugar_conv._get_key(sugar_update))
+
+    # Start profile conversation which should cancel sugar conversation
+    prof_msg = DummyMessage("/profile")
+    prof_update = SimpleNamespace(message=prof_msg, effective_user=SimpleNamespace(id=1), effective_chat=SimpleNamespace(id=1))
+    prof_context = SimpleNamespace(args=[], user_data={})
+    result = await profile_handlers.profile_command(prof_update, prof_context)
+    assert result == profile_handlers.PROFILE_ICR
+    assert "ИКХ" in prof_msg.replies[0]
+
+    # Sugar conversation should be cleared
+    key = dose_handlers.sugar_conv._get_key(prof_update)
+    assert key not in dose_handlers.sugar_conv._conversations
+
+    # Send ICR value
+    icr_msg = DummyMessage("10")
+    icr_update = SimpleNamespace(message=icr_msg, effective_user=SimpleNamespace(id=1), effective_chat=SimpleNamespace(id=1))
+    icr_context = SimpleNamespace(user_data={})
+    result_icr = await profile_handlers.profile_icr(icr_update, icr_context)
+    assert result_icr == profile_handlers.PROFILE_CF
+    assert "КЧ" in icr_msg.replies[0]
+
+    # Ensure no sugar entry was written
+    with TestSession() as session:
+        assert session.query(Entry).count() == 0


### PR DESCRIPTION
## Summary
- register profile conversation before sugar logging so profile inputs aren't misrouted
- cancel any active sugar conversation at `/profile` start
- ensure `bot.main` registers post-init hook after building application
- test that entering IКХ during profile setup doesn't record sugar

## Testing
- `ruff check diabetes tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689208e7f1a0832a969b3c3c90fb6778