### PR TITLE
[reminders] allow adding reminders from list

### DIFF
--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -36,6 +36,9 @@ def test_log_level_debug(monkeypatch):
         def token(self, _):
             return self
 
+        def post_init(self, _):
+            return self
+
         def build(self):
             return DummyApp()
 


### PR DESCRIPTION
## Summary
- show add-reminder button in reminders list, with guidance when empty
- support starting reminder creation from inline button
- adjust debug logging test for builder's post_init API

## Testing
- `ruff check diabetes tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892093a6790832a84d44a2789b5dec0