### PR TITLE
[reminders] improve reminder confirmation and re-entry

### DIFF
--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -258,7 +258,10 @@ async def add_reminder_value(
         job.schedule_removal()
     schedule_reminder(reminder, context.job_queue)
     context.user_data.pop("rem_type", None)
-    await update.message.reply_text(f"Сохранено: {_describe(reminder)}")
+    await update.message.reply_text(
+        f"Сохранено: {_describe(reminder)}. "
+        "Отправьте /addreminder, чтобы добавить ещё."
+    )
     return ConversationHandler.END
 
 
@@ -282,6 +285,7 @@ add_reminder_conv = ConversationHandler(
     },
     fallbacks=[CommandHandler("cancel", add_reminder_cancel)],
     per_message=False,
+    allow_reentry=True,
 )
 
 


### PR DESCRIPTION
## Summary
- Confirm reminder creation with instructions on adding more
- Allow /addreminder to restart the reminder flow
- Test sequential reminder creation to prevent regressions

## Testing
- `ruff check diabetes tests`
- `pytest tests/test_reminders.py::test_add_multiple_reminders_sequential -q`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68920bf654f8832abea5dd794c5278ce