### PR TITLE
[handlers] Add food photo fallback

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -957,6 +957,7 @@ sugar_conv = ConversationHandler(
     fallbacks=[
         MessageHandler(filters.Regex("^↩️ Назад$"), dose_cancel),
         CommandHandler("menu", _cancel_then(menu_command)),
+        MessageHandler(filters.Regex("^📷 Фото еды$"), _cancel_then(photo_prompt)),
     ],
 )
 

--- a/diabetes/onboarding_handlers.py
+++ b/diabetes/onboarding_handlers.py
@@ -288,6 +288,13 @@ async def onboarding_poll_answer(
     logger.info("Onboarding poll result from %s: %s", user_id, option)
 
 
+async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    from .dose_handlers import _cancel_then, photo_prompt
+
+    handler = _cancel_then(photo_prompt)
+    return await handler(update, context)
+
+
 onboarding_conv = ConversationHandler(
     entry_points=[CommandHandler("start", start_command)],
     states={
@@ -312,7 +319,10 @@ onboarding_conv = ConversationHandler(
             CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
         ],
     },
-    fallbacks=[CommandHandler("cancel", onboarding_skip)],
+    fallbacks=[
+        CommandHandler("cancel", onboarding_skip),
+        MessageHandler(filters.Regex("^📷 Фото еды$"), _photo_fallback),
+    ],
     per_message=False,
 )
 

--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -492,6 +492,13 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     return ConversationHandler.END
 
 
+async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    from .dose_handlers import _cancel_then, photo_prompt
+
+    handler = _cancel_then(photo_prompt)
+    return await handler(update, context)
+
+
 profile_conv = ConversationHandler(
     entry_points=[
         CommandHandler("profile", profile_command),
@@ -513,6 +520,7 @@ profile_conv = ConversationHandler(
     fallbacks=[
         MessageHandler(filters.Regex("^↩️ Назад$"), profile_cancel),
         CommandHandler("cancel", profile_cancel),
+        MessageHandler(filters.Regex("^📷 Фото еды$"), _photo_fallback),
     ],
     # Subsequent steps depend on ``MessageHandler`` for text inputs. Enabling
     # ``per_message=True`` would store state per message and reset the

--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -274,6 +274,13 @@ async def add_reminder_cancel(
     return ConversationHandler.END
 
 
+async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    from .dose_handlers import _cancel_then, photo_prompt
+
+    handler = _cancel_then(photo_prompt)
+    return await handler(update, context)
+
+
 add_reminder_conv = ConversationHandler(
     entry_points=[
         CommandHandler("addreminder", add_reminder_start),
@@ -283,7 +290,10 @@ add_reminder_conv = ConversationHandler(
         REMINDER_TYPE: [CallbackQueryHandler(add_reminder_type, pattern="^rem_type:")],
         REMINDER_VALUE: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_reminder_value)],
     },
-    fallbacks=[CommandHandler("cancel", add_reminder_cancel)],
+    fallbacks=[
+        CommandHandler("cancel", add_reminder_cancel),
+        MessageHandler(filters.Regex("^📷 Фото еды$"), _photo_fallback),
+    ],
     per_message=False,
     allow_reentry=True,
 )

--- a/diabetes/sos_handlers.py
+++ b/diabetes/sos_handlers.py
@@ -16,6 +16,8 @@ from telegram.ext import (
 from diabetes.db import SessionLocal, Profile
 from diabetes.ui import back_keyboard, menu_keyboard
 from .common_handlers import commit_session
+from . import dose_handlers
+from .dose_handlers import _cancel_then
 
 SOS_CONTACT, = range(1)
 
@@ -84,6 +86,10 @@ sos_contact_conv = ConversationHandler(
     fallbacks=[
         MessageHandler(filters.Regex("^↩️ Назад$"), sos_contact_cancel),
         CommandHandler("cancel", sos_contact_cancel),
+        MessageHandler(
+            filters.Regex("^📷 Фото еды$"),
+            _cancel_then(dose_handlers.photo_prompt),
+        ),
     ],
     per_message=False,
 )

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+import os
+
+import pytest
+from telegram.ext import MessageHandler
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+import diabetes.openai_utils as openai_utils  # noqa: F401
+from diabetes import (
+    dose_handlers,
+    reminder_handlers,
+    profile_handlers,
+    onboarding_handlers,
+    sos_handlers,
+)
+
+
+class DummyMessage:
+    def __init__(self, text: str = ""):
+        self.text = text
+        self.replies: list[str] = []
+        self.kwargs: list[dict] = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
+
+
+async def _exercise(handler):
+    message = DummyMessage("📷 Фото еды")
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}, "dose_method": "xe"})
+    await handler.callback(update, context)
+    assert message.replies[0] == "Отменено."
+    assert any("фото" in r.lower() for r in message.replies[1:])
+    assert context.user_data == {}
+
+
+@pytest.mark.asyncio
+async def test_add_reminder_conv_photo_fallback():
+    handler = next(
+        h
+        for h in reminder_handlers.add_reminder_conv.fallbacks
+        if isinstance(h, MessageHandler)
+        and getattr(getattr(h, "filters", None), "pattern", None).pattern
+        == "^📷 Фото еды$"
+    )
+    await _exercise(handler)
+
+
+@pytest.mark.asyncio
+async def test_profile_conv_photo_fallback():
+    handler = next(
+        h
+        for h in profile_handlers.profile_conv.fallbacks
+        if isinstance(h, MessageHandler)
+        and getattr(getattr(h, "filters", None), "pattern", None).pattern
+        == "^📷 Фото еды$"
+    )
+    await _exercise(handler)
+
+
+@pytest.mark.asyncio
+async def test_sugar_conv_photo_fallback():
+    handler = next(
+        h
+        for h in dose_handlers.sugar_conv.fallbacks
+        if isinstance(h, MessageHandler)
+        and getattr(getattr(h, "filters", None), "pattern", None).pattern
+        == "^📷 Фото еды$"
+    )
+    await _exercise(handler)
+
+
+@pytest.mark.asyncio
+async def test_onboarding_conv_photo_fallback():
+    handler = next(
+        h
+        for h in onboarding_handlers.onboarding_conv.fallbacks
+        if isinstance(h, MessageHandler)
+        and getattr(getattr(h, "filters", None), "pattern", None).pattern
+        == "^📷 Фото еды$"
+    )
+    await _exercise(handler)
+
+
+@pytest.mark.asyncio
+async def test_sos_contact_conv_photo_fallback():
+    handler = next(
+        h
+        for h in sos_handlers.sos_contact_conv.fallbacks
+        if isinstance(h, MessageHandler)
+        and getattr(getattr(h, "filters", None), "pattern", None).pattern
+        == "^📷 Фото еды$"
+    )
+    await _exercise(handler)


### PR DESCRIPTION
## Summary
- allow reminder, profile, sugar, onboarding, and SOS flows to cancel and prompt for a food photo via a shared fallback handler
- cover new photo fallbacks with unit tests

## Testing
- `ruff check diabetes tests`
- `pytest tests/test_photo_fallbacks.py tests/test_dose_conv_photo_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_68920d9e237c832a85fc30de3b54ae15