### PR TITLE
[bot] Use builder-based post_init registration

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -50,8 +50,12 @@ def main() -> None:
     async def post_init(app: Application) -> None:
         await app.bot.set_my_commands(commands)
 
-    application = Application.builder().token(BOT_TOKEN).build()
-    application.post_init.append(post_init)
+    application = (
+        Application.builder()
+        .token(BOT_TOKEN)
+        .post_init(post_init)  # registers post-init handler
+        .build()
+    )
     register_handlers(application)
     application.run_polling()
 

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -27,7 +27,6 @@ def test_log_level_debug(monkeypatch):
 
     class DummyApp:
         bot = DummyBot()
-        post_init = []
 
         def run_polling(self):
             return None


### PR DESCRIPTION
## Summary
- Register post-init handler via `Application.builder().post_init(...)` rather than mutating `post_init` list
- Clean up debug logging test to match builder-based registration

## Testing
- `ruff check diabetes tests`
- `pytest -q`
- manual bot run verifying commands set

------
https://chatgpt.com/codex/tasks/task_e_68921240be7c832aaa76e22b8d70511b