### PR TITLE
[reminders] Add enable toggle for reminders

### DIFF
--- a/alembic/versions/c0d1e2f3a4b5_add_reminder_is_enabled.py
+++ b/alembic/versions/c0d1e2f3a4b5_add_reminder_is_enabled.py
@@ -1,0 +1,30 @@
+"""add is_enabled to reminders
+
+Revision ID: c0d1e2f3a4b5
+Revises: b5a1c2d3e4f6
+Create Date: 2025-09-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'c0d1e2f3a4b5'
+down_revision: Union[str, None] = 'b5a1c2d3e4f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'reminders',
+        sa.Column('is_enabled', sa.Boolean(), server_default=sa.true(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('reminders', 'is_enabled')

--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -333,6 +333,7 @@ def register_handlers(app: Application) -> None:
         CallbackQueryHandler(profile_handlers.profile_back, pattern="^profile_back$")
     )
     app.add_handler(CallbackQueryHandler(reminder_handlers.reminder_callback, pattern="^remind_"))
+    app.add_handler(CallbackQueryHandler(reminder_handlers.toggle_reminder_cb, pattern="^toggle:"))
     app.add_handler(CallbackQueryHandler(callback_router))
 
     job_queue = app.job_queue

--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -84,6 +84,7 @@ class Reminder(Base):
     time = Column(String)  # HH:MM format for daily reminders
     interval_hours = Column(Integer)  # for repeating reminders
     minutes_after = Column(Integer)  # for after-meal reminders
+    is_enabled = Column(Boolean, default=True)
     created_at = Column(TIMESTAMP(timezone=True), server_default=func.now())
     user = relationship("User")
 

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -10,7 +10,7 @@ from telegram.ext import (
 from diabetes.callbackquery_no_warn_handler import CallbackQueryNoWarnHandler
 
 from diabetes.common_handlers import register_handlers, callback_router, start_command
-from diabetes import security_handlers
+from diabetes import security_handlers, reminder_handlers
 
 
 def test_register_handlers_attaches_expected_handlers(monkeypatch):
@@ -39,6 +39,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert reporting_handlers.history_view in callbacks
     assert dose_handlers.chat_with_gpt in callbacks
     assert security_handlers.hypo_alert_faq in callbacks
+    assert reminder_handlers.toggle_reminder_cb in callbacks
 
     onb_conv = [
         h


### PR DESCRIPTION
## Summary
- add `is_enabled` flag to `Reminder` model and migration
- allow toggling reminders with new `toggle` callbacks and handler
- skip disabled reminders when scheduling jobs

## Testing
- `ruff check diabetes tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68921b5a4658832abdd7cfef68e8abe3