### PR TITLE
[reminders] add inline actions and callbacks

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -334,6 +334,7 @@ def register_handlers(app: Application) -> None:
     )
     app.add_handler(CallbackQueryHandler(reminder_handlers.reminder_callback, pattern="^remind_"))
     app.add_handler(CallbackQueryHandler(reminder_handlers.toggle_reminder_cb, pattern="^toggle:"))
+    app.add_handler(CallbackQueryHandler(reminder_handlers.delete_reminder_cb, pattern="^del:"))
     app.add_handler(CallbackQueryHandler(callback_router))
 
     job_queue = app.job_queue

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -40,6 +40,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert dose_handlers.chat_with_gpt in callbacks
     assert security_handlers.hypo_alert_faq in callbacks
     assert reminder_handlers.toggle_reminder_cb in callbacks
+    assert reminder_handlers.delete_reminder_cb in callbacks
 
     onb_conv = [
         h


### PR DESCRIPTION
## Summary
- add inline buttons for editing, deleting, and toggling reminders
- implement callback handlers with confirmation via answerCallbackQuery
- cover reminder callbacks with tests

## Testing
- `ruff check diabetes tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68921e49d14c832a8c6c543a679c82dc