### PR TITLE
[reminders] Enhance reminder descriptions with schedule info

### DIFF
--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -185,7 +185,7 @@ async def test_profile_security_shows_reminders(monkeypatch):
     await handlers.profile_security(update, context)
 
     text, _ = query.edits[0]
-    assert "1. Замерить сахар 08:00" in text
+    assert "1. 🔔 Замерить сахар ⏰ 08:00" in text
 
 
 @pytest.mark.asyncio

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -350,7 +350,7 @@ async def test_trigger_job_logs(monkeypatch):
         job_queue=job_queue,
     )
     await handlers.reminder_job(context)
-    assert bot.messages[0][1].startswith("Замерить сахар")
+    assert bot.messages[0][1].startswith("🔔 Замерить сахар")
     with TestSession() as session:
         log = session.query(ReminderLog).first()
         assert log.action == "trigger"


### PR DESCRIPTION
## Summary
- enrich reminder descriptions with status icons, schedule type and next run time
- adjust reminder list rendering to use unified descriptions
- update tests for the new reminder output format

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6892239ab128832ab72ee37a31de7d39