### PR TITLE
[db] Add plan field and Pro reminder limit CTA

### DIFF
--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -24,6 +24,7 @@ class User(Base):
     telegram_id = Column(BigInteger, primary_key=True, index=True)
     thread_id = Column(String, nullable=False)
     onboarding_complete = Column(Boolean, default=False)
+    plan = Column(String, default="free")
     created_at = Column(TIMESTAMP(timezone=True), server_default=func.now())
 
 


### PR DESCRIPTION
## Summary
- store user plan in the User model with default `free`
- set reminder limit based on user plan and hint about upgrading to Pro

## Testing
- `ruff check diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68923a7941bc832aa6895a3f0991669d