### PR TITLE
[bot] Handle init_db errors gracefully

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -31,9 +31,11 @@ def main() -> None:
 
     try:
         init_db()
-    except SQLAlchemyError:
-        logger.exception("Failed to initialize the database")
-        sys.exit(1)
+    except (SQLAlchemyError, ValueError) as err:
+        logger.exception("Failed to initialize the database: %s", err)
+        sys.exit(
+            "Database initialization failed. Please check your configuration and try again."
+        )
 
     commands = [
         BotCommand("start", "Запустить бота"),

--- a/tests/test_bot_db_error.py
+++ b/tests/test_bot_db_error.py
@@ -18,7 +18,13 @@ def test_main_logs_db_error(monkeypatch, caplog):
         with pytest.raises(SystemExit) as exc:
             asyncio.run(bot.main())
 
-    assert exc.value.code == 1
+    assert (
+        exc.value.code
+        == (
+            "Database initialization failed. Please check your configuration "
+            "and try again."
+        )
+    )
     assert any(
         "Failed to initialize the database" in record.getMessage()
         for record in caplog.records


### PR DESCRIPTION
## Summary
- log DB initialization errors with details and exit with a helpful message to the user
- update failing test to expect the new exit message

## Testing
- `ruff check diabetes tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892590f581c832a83ae4e3a08817c22