### PR TITLE
[gpt_client] Handle thread creation errors

### DIFF
--- a/diabetes/gpt_client.py
+++ b/diabetes/gpt_client.py
@@ -24,7 +24,11 @@ def _get_client():
 
 def create_thread() -> str:
     """Создаём пустой thread (ассистент задаётся позже, в runs.create)."""
-    thread = _get_client().beta.threads.create()
+    try:
+        thread = _get_client().beta.threads.create()
+    except OpenAIError as exc:
+        logging.exception("[OpenAI] Failed to create thread: %s", exc)
+        raise
     return thread.id
 
 

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -56,3 +56,18 @@ def test_send_message_openaierror(monkeypatch, caplog):
             gpt_client.send_message(thread_id="t", content="hi")
 
     assert any("Failed to create message" in r.message for r in caplog.records)
+
+
+def test_create_thread_openaierror(monkeypatch, caplog):
+    def raise_error():
+        raise OpenAIError("boom")
+
+    fake_client = SimpleNamespace(beta=SimpleNamespace(threads=SimpleNamespace(create=raise_error)))
+
+    monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(OpenAIError):
+            gpt_client.create_thread()
+
+    assert any("Failed to create thread" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- Guard thread creation with OpenAIError handler and log exception
- Add unit test verifying thread creation error logging

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689260c71bf4832a85eef1734cb1c359