### PR TITLE
[deps] add job-queue extra for python-telegram-bot

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -339,7 +339,10 @@ def register_handlers(app: Application) -> None:
 
     job_queue = app.job_queue
     if job_queue:
-        reminder_handlers.schedule_all(job_queue)
+        try:
+            reminder_handlers.schedule_all(job_queue)
+        except SQLAlchemyError:
+            logger.exception("Failed to schedule reminders")
 
 
 __all__ = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ pytest==8.4.1
 pytest-asyncio==1.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
-python-telegram-bot==20.4
+python-telegram-bot[job-queue]==20.4
 reportlab==4.4.3
 six==1.17.0
 sniffio==1.3.1


### PR DESCRIPTION
## Summary
- add python-telegram-bot job-queue dependency
- guard scheduling with SQLAlchemy error handling

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6892668e1860832a8d476818a13234fd