### PR TITLE
[reminders] Consolidate reminder callbacks

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -333,8 +333,8 @@ def register_handlers(app: Application) -> None:
         CallbackQueryHandler(profile_handlers.profile_back, pattern="^profile_back$")
     )
     app.add_handler(CallbackQueryHandler(reminder_handlers.reminder_callback, pattern="^remind_"))
-    app.add_handler(CallbackQueryHandler(reminder_handlers.toggle_reminder_cb, pattern="^toggle:"))
-    app.add_handler(CallbackQueryHandler(reminder_handlers.delete_reminder_cb, pattern="^del:"))
+    app.add_handler(reminder_handlers.reminder_action_handler)
+    app.add_handler(reminder_handlers.reminder_edit_handler)
     app.add_handler(CallbackQueryHandler(callback_router))
 
     job_queue = app.job_queue

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -39,8 +39,8 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert reporting_handlers.history_view in callbacks
     assert dose_handlers.chat_with_gpt in callbacks
     assert security_handlers.hypo_alert_faq in callbacks
-    assert reminder_handlers.toggle_reminder_cb in callbacks
-    assert reminder_handlers.delete_reminder_cb in callbacks
+    assert reminder_handlers.reminder_action_cb in callbacks
+    assert reminder_handlers.reminder_edit_reply in callbacks
 
     onb_conv = [
         h


### PR DESCRIPTION
## Summary
- handle reminder edit, delete and toggle via single `reminder_action_cb`
- strike through disabled reminders and validate edits with `parse_time_interval`
- wire new handlers into registration and adjust tests

## Testing
- `ruff check diabetes tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6892c7f992f4832aae7d9cf67203a022