### PR TITLE
[utils] Add parse_time_interval helper

### DIFF
--- a/tests/test_parse_time_interval.py
+++ b/tests/test_parse_time_interval.py
@@ -1,0 +1,22 @@
+from datetime import time, timedelta
+
+import pytest
+
+from diabetes.utils import parse_time_interval, INVALID_TIME_MSG
+
+
+def test_parse_time_success():
+    assert parse_time_interval("22:30") == time(22, 30)
+    assert parse_time_interval("6:00") == time(6, 0)
+
+
+def test_parse_interval_success():
+    assert parse_time_interval("5h") == timedelta(hours=5)
+    assert parse_time_interval("3d") == timedelta(days=3)
+
+
+@pytest.mark.parametrize("value", ["", "25:00", "5x", "1:60"])
+def test_parse_time_invalid(value):
+    with pytest.raises(ValueError) as exc:
+        parse_time_interval(value)
+    assert str(exc.value) == INVALID_TIME_MSG


### PR DESCRIPTION
## Summary
- add `parse_time_interval` to utils for parsing `HH:MM`, `Nh`, `Nd`
- use helper in reminder add/edit flows
- test valid and invalid interval parsing

## Testing
- `ruff check diabetes tests`
- `pytest tests/test_parse_time_interval.py tests/test_add_reminder_wizard.py tests/test_reminders.py`


------
https://chatgpt.com/codex/tasks/task_e_6892cf897054832aa1a0c6118170c6a3