### PR TITLE
[tests] add parse interval and reminder limit cases

### DIFF
--- a/tests/test_parse_time_interval.py
+++ b/tests/test_parse_time_interval.py
@@ -2,20 +2,35 @@ from datetime import time, timedelta
 
 import pytest
 
-from diabetes.utils import parse_time_interval, INVALID_TIME_MSG
+from diabetes.utils import INVALID_TIME_MSG, parse_time_interval
 
 
-def test_parse_time_success():
-    assert parse_time_interval("22:30") == time(22, 30)
-    assert parse_time_interval("6:00") == time(6, 0)
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("22:30", time(22, 30)),
+        ("6:00", time(6, 0)),
+    ],
+)
+def test_parse_time_success(text, expected):
+    assert parse_time_interval(text) == expected
 
 
-def test_parse_interval_success():
-    assert parse_time_interval("5h") == timedelta(hours=5)
-    assert parse_time_interval("3d") == timedelta(days=3)
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("5h", timedelta(hours=5)),
+        ("3d", timedelta(days=3)),
+    ],
+)
+def test_parse_interval_success(text, expected):
+    assert parse_time_interval(text) == expected
 
 
-@pytest.mark.parametrize("value", ["", "25:00", "5x", "1:60"])
+@pytest.mark.parametrize(
+    "value",
+    ["", "25:00", "5x", "1:60", "2h30", "3 d"],
+)
 def test_parse_time_invalid(value):
     with pytest.raises(ValueError) as exc:
         parse_time_interval(value)

--- a/tests/test_reminder_limit_free_vs_pro.py
+++ b/tests/test_reminder_limit_free_vs_pro.py
@@ -1,10 +1,11 @@
-import pytest
 from types import SimpleNamespace
+
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from diabetes.db import Base, User, Reminder
 import diabetes.reminder_handlers as handlers
+from diabetes.db import Base, Reminder, User
 
 
 class DummyMessage:
@@ -12,21 +13,21 @@ class DummyMessage:
         self.text = text
         self.replies: list[str] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text, **kwargs):  # pragma: no cover - kwargs unused
         self.replies.append(text)
 
 
 @pytest.mark.asyncio
-async def test_reminder_limit_free_vs_pro():
+@pytest.mark.parametrize("plan, limit", [("free", 5), ("pro", 10)])
+async def test_reminder_limit_free_vs_pro(plan, limit, monkeypatch):
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    handlers.SessionLocal = TestSession
+    monkeypatch.setattr(handlers, "SessionLocal", TestSession)
 
-    # Free plan user with 5 active reminders and one disabled
     with TestSession() as session:
-        session.add(User(telegram_id=1, thread_id="t1", plan="free"))
-        for _ in range(5):
+        session.add(User(telegram_id=1, thread_id="t", plan=plan))
+        for _ in range(limit):
             session.add(
                 Reminder(
                     telegram_id=1,
@@ -35,42 +36,15 @@ async def test_reminder_limit_free_vs_pro():
                     is_enabled=True,
                 )
             )
-        session.add(
-            Reminder(
-                telegram_id=1,
-                type="sugar",
-                time="10:00",
-                is_enabled=False,
-            )
-        )
         session.commit()
 
     msg = DummyMessage()
     update = SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+
     state = await handlers.add_reminder_start(update, SimpleNamespace())
+
     assert state == handlers.ConversationHandler.END
     assert msg.replies[-1] == (
-        "У вас уже 5 активных (лимит FREE). Отключите одно или откройте PRO."
+        f"У вас уже {limit} активных (лимит {plan.upper()}). Отключите одно или откройте PRO."
     )
 
-    # Pro plan user with 10 active reminders
-    with TestSession() as session:
-        session.add(User(telegram_id=2, thread_id="t2", plan="pro"))
-        for _ in range(10):
-            session.add(
-                Reminder(
-                    telegram_id=2,
-                    type="sugar",
-                    time="10:00",
-                    is_enabled=True,
-                )
-            )
-        session.commit()
-
-    msg2 = DummyMessage()
-    update2 = SimpleNamespace(message=msg2, effective_user=SimpleNamespace(id=2))
-    state2 = await handlers.add_reminder_start(update2, SimpleNamespace())
-    assert state2 == handlers.ConversationHandler.END
-    assert msg2.replies[-1] == (
-        "У вас уже 10 активных (лимит PRO). Отключите одно или откройте PRO."
-    )


### PR DESCRIPTION
## Summary
- add parameterized tests for `parse_time_interval`
- verify reminder limits for FREE and PRO plans using in-memory DB

## Testing
- `ruff check diabetes tests`
- `pytest tests/test_parse_time_interval.py tests/test_reminder_limit_free_vs_pro.py`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6892dc2d683c832a8438a3987d265c94