### PR TITLE
[reminders] narrow edit reply filter

### DIFF
--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -650,5 +650,5 @@ reminder_action_handler = CallbackQueryHandler(
     reminder_action_cb, pattern="^(edit|del|toggle):"
 )
 reminder_edit_handler = MessageHandler(
-    filters.REPLY & filters.TEXT, reminder_edit_reply
+    filters.REPLY & filters.Regex(r"^([0-9]{1,2}:[0-9]{2}|[0-9]+[hd])$"), reminder_edit_reply
 )


### PR DESCRIPTION
## Summary
- limit reminder edit replies to time/interval formats so diary updates aren't triggered

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6892e4919534832a9b6139e31591b9b0