### PR TITLE
[reminders] Prefix callback data for reminder actions

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -64,6 +64,9 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     await query.answer()
     data = query.data
 
+    if data.startswith("rem_"):
+        return
+
     if data == "confirm_entry":
         entry_data = context.user_data.pop("pending_entry", None)
         if not entry_data:

--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -125,9 +125,9 @@ def _render_reminders(user_id: int) -> tuple[str, InlineKeyboardMarkup]:
         line = f"{r.id}. {title}"
         status_icon = "🔔" if r.is_enabled else "🔕"
         row = [
-            InlineKeyboardButton("✏️", callback_data=f"edit:{r.id}"),
-            InlineKeyboardButton("🗑️", callback_data=f"del:{r.id}"),
-            InlineKeyboardButton(status_icon, callback_data=f"toggle:{r.id}"),
+            InlineKeyboardButton("✏️", callback_data=f"rem_edit:{r.id}"),
+            InlineKeyboardButton("🗑️", callback_data=f"rem_del:{r.id}"),
+            InlineKeyboardButton(status_icon, callback_data=f"rem_toggle:{r.id}"),
         ]
         if r.time:
             by_time.append((line, row))
@@ -551,7 +551,11 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
 
 async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
-    action, rid_str = query.data.split(":", 1)
+    action_raw, rid_str = query.data.split(":", 1)
+    if not action_raw.startswith("rem_"):
+        await query.answer("Некорректное действие", show_alert=True)
+        return
+    action = action_raw.removeprefix("rem_")
     try:
         rid = int(rid_str)
     except ValueError:
@@ -661,7 +665,7 @@ def schedule_after_meal(user_id: int, job_queue) -> None:
 
 
 reminder_action_handler = CallbackQueryHandler(
-    reminder_action_cb, pattern="^(edit|del|toggle):"
+    reminder_action_cb, pattern="^rem_(edit|del|toggle):"
 )
 reminder_edit_handler = MessageHandler(
     filters.REPLY & filters.Regex(r"^([0-9]{1,2}:[0-9]{2}|[0-9]+[hd])$"), reminder_edit_reply

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -83,3 +83,20 @@ async def test_callback_router_unknown_data(caplog):
 
     assert query.edited == ["Команда не распознана"]
     assert "Unrecognized callback data" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_callback_router_ignores_reminder_action():
+    os.environ["OPENAI_API_KEY"] = "test"
+    os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
+    import diabetes.openai_utils  # noqa: F401
+    import diabetes.common_handlers as handlers
+
+    query = DummyQuery("rem_toggle:1")
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace(user_data={"pending_entry": {}})
+
+    await handlers.callback_router(update, context)
+
+    assert query.edited == []
+    assert "pending_entry" in context.user_data


### PR DESCRIPTION
## Summary
- prefix reminder action buttons with `rem_` and update handler patterns
- ignore reminder callbacks in `callback_router`
- adjust tests for new callback prefixes and pending-entry safety

## Testing
- `ruff check diabetes tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68930967ced4832ab3f6553f8628f68a