### PR TITLE
[dose] Omit unit when dose missing

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -352,7 +352,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         xe = pending_entry.get("xe")
         dose = pending_entry.get("dose")
         xe_info = f", ХЕ {xe}" if xe is not None else ""
-        dose_info = f", доза {dose} Ед." if dose is not None else ", доза — Ед."
+        dose_info = f", доза {dose} Ед." if dose is not None else ", доза —"
         await update.message.reply_text(
             f"✅ Запись сохранена: сахар {sugar} ммоль/л{xe_info}{dose_info}",
             reply_markup=menu_keyboard,

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -1,0 +1,60 @@
+import datetime
+from types import SimpleNamespace
+import os
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+import diabetes.openai_utils as openai_utils  # noqa: F401
+import diabetes.dose_handlers as dose_handlers
+
+
+class DummyMessage:
+    def __init__(self, text):
+        self.text = text
+        self.replies = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_entry_without_dose_has_no_unit(monkeypatch):
+    pending_entry = {
+        "telegram_id": 1,
+        "event_time": datetime.datetime.now(datetime.timezone.utc),
+        "xe": 2.0,
+    }
+    context = SimpleNamespace(
+        user_data={"pending_entry": pending_entry, "pending_fields": ["sugar"]}
+    )
+    message = DummyMessage("5.5")
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def add(self, entry):
+            self.entry = entry
+
+    async def noop(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(dose_handlers, "SessionLocal", lambda: DummySession())
+    monkeypatch.setattr(dose_handlers, "commit_session", lambda session: True)
+    monkeypatch.setattr(dose_handlers, "check_alert", noop)
+    monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
+
+    await dose_handlers.freeform_handler(update, context)
+
+    assert not context.user_data
+    assert message.replies
+    text = message.replies[0]
+    assert "доза —" in text
+    assert "Ед" not in text
+


### PR DESCRIPTION
## Summary
- avoid displaying insulin unit when dose is absent
- test that saved entries without dose omit unit in the confirmation message

## Testing
- `ruff check diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68932de24c30832ab0c3a76859971587