### PR TITLE
[reminders] Guard reminder edit with conversation

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -310,6 +310,8 @@ def register_handlers(app: Application) -> None:
     app.add_handler(
         MessageHandler(filters.Regex("^ℹ️ Помощь$"), help_command)
     )
+    # Reminder edit conversation should run before generic free-form handler
+    app.add_handler(reminder_handlers.reminder_edit_conv)
     app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, dose_handlers.freeform_handler)
     )
@@ -336,8 +338,6 @@ def register_handlers(app: Application) -> None:
         CallbackQueryHandler(profile_handlers.profile_back, pattern="^profile_back$")
     )
     app.add_handler(CallbackQueryHandler(reminder_handlers.reminder_callback, pattern="^remind_"))
-    app.add_handler(reminder_handlers.reminder_action_handler)
-    app.add_handler(reminder_handlers.reminder_edit_handler)
     app.add_handler(CallbackQueryHandler(callback_router))
 
     job_queue = app.job_queue

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -39,8 +39,23 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert reporting_handlers.history_view in callbacks
     assert dose_handlers.chat_with_gpt in callbacks
     assert security_handlers.hypo_alert_faq in callbacks
-    assert reminder_handlers.reminder_action_cb in callbacks
-    assert reminder_handlers.reminder_edit_reply in callbacks
+    # Reminder edit conversation should be registered
+    reminder_convs = [
+        h
+        for h in handlers
+        if isinstance(h, ConversationHandler)
+        and any(
+            isinstance(ep, CallbackQueryHandler)
+            and ep.callback is reminder_handlers.reminder_action_cb
+            for ep in h.entry_points
+        )
+    ]
+    assert reminder_convs
+    assert any(
+        isinstance(h, MessageHandler)
+        and h.callback is reminder_handlers.reminder_edit_reply
+        for h in reminder_convs[0].states.get(reminder_handlers.REM_EDIT_AWAIT_INPUT, [])
+    )
 
     onb_conv = [
         h

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -1,0 +1,116 @@
+import pytest
+
+import diabetes.reminder_handlers as handlers
+from diabetes.common_handlers import commit_session
+from diabetes.db import Base, User, Reminder, Entry
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from types import SimpleNamespace
+
+
+class DummyMessage:
+    def __init__(self, text: str | None = None):
+        self.text = text
+        self.replies: list[str] = []
+        self.edited = None
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+
+    async def edit_text(self, text, **kwargs):
+        self.edited = (text, kwargs)
+
+
+class DummyCallbackQuery:
+    def __init__(self, data: str, message: DummyMessage, id: str = "1"):
+        self.data = data
+        self.message = message
+        self.id = id
+        self.answers: list[str | None] = []
+
+    async def answer(self, text: str | None = None, **kwargs):
+        self.answers.append(text)
+
+
+class DummyBot:
+    def __init__(self):
+        self.cb_answers: list[tuple[str, str | None]] = []
+
+    async def answer_callback_query(self, callback_query_id, text: str | None = None, **kwargs):
+        self.cb_answers.append((callback_query_id, text))
+
+
+class DummyJobQueue:
+    def get_jobs_by_name(self, name):
+        return []
+
+    def run_daily(self, *args, **kwargs):
+        pass
+
+    def run_repeating(self, *args, **kwargs):
+        pass
+
+
+def _setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    handlers.SessionLocal = TestSession
+    handlers.commit_session = commit_session
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.add(
+            Reminder(
+                id=1,
+                telegram_id=1,
+                type="sugar",
+                time="08:00",
+                is_enabled=True,
+            )
+        )
+        session.commit()
+    return TestSession
+
+
+@pytest.mark.asyncio
+async def test_bad_input_does_not_create_entry():
+    TestSession = _setup_db()
+    context = SimpleNamespace(user_data={}, job_queue=DummyJobQueue(), bot=DummyBot())
+    cq = DummyCallbackQuery("rem_edit:1", DummyMessage())
+    update = SimpleNamespace(callback_query=cq, effective_user=SimpleNamespace(id=1))
+    state = await handlers.reminder_action_cb(update, context)
+    assert state == handlers.REM_EDIT_AWAIT_INPUT
+
+    msg = DummyMessage(text="5")
+    update2 = SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    state = await handlers.reminder_edit_reply(update2, context)
+    assert state == handlers.REM_EDIT_AWAIT_INPUT
+    assert msg.replies and "Неверный формат" in msg.replies[0]
+    with TestSession() as session:
+        assert session.query(Entry).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_good_input_updates_and_ends():
+    TestSession = _setup_db()
+    context = SimpleNamespace(user_data={}, job_queue=DummyJobQueue(), bot=DummyBot())
+    msg_initial = DummyMessage()
+    cq = DummyCallbackQuery("rem_edit:1", msg_initial, id="cb1")
+    update = SimpleNamespace(callback_query=cq, effective_user=SimpleNamespace(id=1))
+    state = await handlers.reminder_action_cb(update, context)
+    assert state == handlers.REM_EDIT_AWAIT_INPUT
+
+    msg = DummyMessage(text="09:30")
+    update2 = SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    end_state = await handlers.reminder_edit_reply(update2, context)
+    assert end_state == handlers.ConversationHandler.END
+    assert context.bot.cb_answers == [("cb1", "Готово ✅")]
+    assert msg_initial.edited is not None
+    with TestSession() as session:
+        rem = session.get(Reminder, 1)
+        assert rem.time == "09:30"
+        assert rem.interval_hours is None
+        assert session.query(Entry).count() == 0
+    assert "edit_reminder_id" not in context.user_data
+


### PR DESCRIPTION
## Summary
- protect reminder edits with a conversation substate so free-form handler can't leak input
- register edit conversation before free-form handler
- cover reminder edit flow including bad input

## Testing
- `ruff check diabetes tests`
- `pytest -q`
- `coverage run -m pytest -q`
- `coverage report -m`
- `mypy diabetes tests --strict` *(fails: Missing target module, package, files, or command)*
- `mypy diabetes --strict` *(fails: 595 errors in 15 files)*

------
https://chatgpt.com/codex/tasks/task_e_68932ff471cc832aa6b0af5c9ebd5d98