### PR TITLE
[reminders] Remove callback query id storage

### DIFF
--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -570,7 +570,6 @@ async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE)
     if action == "edit":
         context.user_data["edit_reminder_id"] = rid
         context.user_data["reminders_msg"] = query.message
-        context.user_data["cbq_id"] = query.id
         await query.message.reply_text(
             "Введите новое время ЧЧ:ММ или новый интервал (5h / 3d)",
             reply_markup=ForceReply(selective=True),
@@ -651,9 +650,7 @@ async def reminder_edit_reply(update: Update, context: ContextTypes.DEFAULT_TYPE
             pass
         else:
             raise
-    cbq_id = context.user_data.pop("cbq_id", None)
-    if cbq_id:
-        await context.bot.answer_callback_query(cbq_id, text="Готово ✅")
+    await update.message.reply_text("Готово ✅")
     context.user_data.pop("edit_reminder_id", None)
     context.user_data.pop("reminders_msg", None)
     return ConversationHandler.END

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -105,7 +105,7 @@ async def test_good_input_updates_and_ends():
     update2 = SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
     end_state = await handlers.reminder_edit_reply(update2, context)
     assert end_state == handlers.ConversationHandler.END
-    assert context.bot.cb_answers == [("cb1", "Готово ✅")]
+    assert msg.replies and msg.replies[-1] == "Готово ✅"
     assert msg_initial.edited is not None
     with TestSession() as session:
         rem = session.get(Reminder, 1)

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -237,9 +237,8 @@ async def test_edit_reminder(monkeypatch):
         rem = session.get(Reminder, 1)
         handlers.schedule_reminder(rem, job_queue)
 
-    bot = DummyBot()
     query = DummyCallbackQuery("rem_edit:1", DummyMessage(), id="cb1")
-    context = SimpleNamespace(user_data={}, job_queue=job_queue, bot=bot)
+    context = SimpleNamespace(user_data={}, job_queue=job_queue, bot=DummyBot())
     update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
     state = await handlers.reminder_action_cb(update, context)
     assert state == handlers.REM_EDIT_AWAIT_INPUT
@@ -249,7 +248,7 @@ async def test_edit_reminder(monkeypatch):
     update2 = SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
     end_state = await handlers.reminder_edit_reply(update2, context)
     assert end_state == handlers.ConversationHandler.END
-    assert bot.cb_answers == [("cb1", "Готово ✅")]
+    assert msg.texts and msg.texts[-1] == "Готово ✅"
 
     with TestSession() as session:
         parsed = parse_time_interval("09:00")


### PR DESCRIPTION
## Summary
- simplify reminder edit flow by dropping callback query id storage
- acknowledge reminder edits via chat message instead of callback query
- adjust tests for new acknowledgement behavior

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689339148f68832a8a0c5df3a0daecde