### PR TITLE
[bot] add application error handler

### DIFF
--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -28,6 +28,9 @@ def test_log_level_debug(monkeypatch):
     class DummyApp:
         bot = DummyBot()
 
+        def add_error_handler(self, _):
+            return None
+
         def run_polling(self):
             return None
 


### PR DESCRIPTION
## Summary
- log unexpected exceptions via new async error handler
- notify maintainers of errors when MAINTAINER_CHAT_ID is set
- attach error handler to Application and update tests

## Testing
- `ruff check bot.py diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68933b004158832aa375f99f116b7870