### PR TITLE
[profile] fix add button handler

### DIFF
--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -245,7 +245,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             profile.sos_alerts_enabled = not profile.sos_alerts_enabled
             changed = True
         elif action == "add":
-            await reminder_handlers.add_reminder(update, context)
+            await reminder_handlers.add_reminder_start(update, context)
         elif action == "del":
             await reminder_handlers.delete_reminder(update, context)
 

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -209,7 +209,7 @@ async def test_profile_security_add_delete_calls_handlers(monkeypatch):
     async def fake_del(update, context):
         called["del"] = True
 
-    monkeypatch.setattr(reminder_handlers, "add_reminder", fake_add)
+    monkeypatch.setattr(reminder_handlers, "add_reminder_start", fake_add)
     monkeypatch.setattr(reminder_handlers, "delete_reminder", fake_del)
 
     query_add = DummyQuery("profile_security:add")


### PR DESCRIPTION
## Summary
- fix profile security add button to start reminder wizard
- update unit test to check new handler call

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68934196e5d8832a8a9072932e2ebfd8