### PR TITLE
[ui] add sos contact menu button

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -311,6 +311,11 @@ def register_handlers(app: Application) -> None:
     app.add_handler(
         MessageHandler(filters.Regex("^ℹ️ Помощь$"), help_command)
     )
+    app.add_handler(
+        MessageHandler(
+            filters.Regex("^🆘 SOS контакт$"), sos_handlers.sos_contact_start
+        )
+    )
     # Reminder edit conversation should run before generic free-form handler
     app.add_handler(reminder_handlers.reminder_edit_conv)
     app.add_handler(

--- a/diabetes/ui.py
+++ b/diabetes/ui.py
@@ -30,7 +30,7 @@ menu_keyboard = ReplyKeyboardMarkup(
         [KeyboardButton("💉 Доза инсулина"), KeyboardButton("📊 История")],
         [KeyboardButton("📈 Отчёт"), KeyboardButton("📄 Мой профиль")],
         [KeyboardButton("🕹 Быстрый ввод"), KeyboardButton("ℹ️ Помощь")],
-        [KeyboardButton("⏰ Напоминания")],
+        [KeyboardButton("⏰ Напоминания"), KeyboardButton("🆘 SOS контакт")],
     ],
     resize_keyboard=True,
     one_time_keyboard=False,


### PR DESCRIPTION
## Summary
- add "SOS контакт" to menu keyboard
- map new button to SOS contact handler
- test that SOS menu button launches contact flow

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6893529145c4832a9c0956bef6828f59