### PR TITLE
[gpt_command_parser] Sort standard imports

### DIFF
--- a/diabetes/gpt_command_parser.py
+++ b/diabetes/gpt_command_parser.py
@@ -1,7 +1,7 @@
+import asyncio
 import json
 import logging
 import re
-import asyncio
 
 from openai import OpenAIError
 


### PR DESCRIPTION
## Summary
- sort built-in imports in gpt_command_parser for consistency

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68935cd9eee8832aa7104a8eafe7da5c