### PR TITLE
[alerts] Ensure datetime import for scheduling

### DIFF
--- a/diabetes/alert_handlers.py
+++ b/diabetes/alert_handlers.py
@@ -1,7 +1,7 @@
 
 from __future__ import annotations
 
-import datetime
+import datetime  # for scheduling delays and stats
 import logging
 
 from telegram.ext import ContextTypes


### PR DESCRIPTION
## Summary
- clarify datetime usage in alert handlers to manage scheduling delays and stats

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68935f5d6670832abf2a700fb906b076