### PR TITLE
[reminders] Reorder datetime import

### DIFF
--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, time, timedelta
+from datetime import datetime, timedelta, time
 import logging
 
 from diabetes.utils import parse_time_interval


### PR DESCRIPTION
## Summary
- reorder `datetime` import to include `timedelta` before `time`

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68936d1f0aac832a8a5ea72de970b2e2