### PR TITLE
Return DiagnoseResponse object from ai_diagnose

### DIFF
--- a/api.py
+++ b/api.py
@@ -11,7 +11,7 @@ class DiagnoseResponse(BaseModel):
     protocol: str | None
 
 @app.post("/v1/ai/diagnose", response_model=DiagnoseResponse)
-async def ai_diagnose(req: DiagnoseRequest):
+async def ai_diagnose(req: DiagnoseRequest) -> DiagnoseResponse:
     protocol = find_protocol_by_diagnosis(req.diagnosis)
-    return {"protocol": protocol}
+    return DiagnoseResponse(protocol=protocol)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,10 +5,10 @@ from api import ai_diagnose, DiagnoseRequest
 @pytest.mark.asyncio
 async def test_ai_diagnose_with_protocol():
     result = await ai_diagnose(DiagnoseRequest(diagnosis="диабет 2 типа"))
-    assert result["protocol"] == "standard protocol"
+    assert result.protocol == "standard protocol"
 
 @pytest.mark.asyncio
 async def test_ai_diagnose_without_protocol():
     result = await ai_diagnose(DiagnoseRequest(diagnosis="unknown"))
-    assert result["protocol"] is None
+    assert result.protocol is None
 


### PR DESCRIPTION
## Summary
- Return `DiagnoseResponse` object in `ai_diagnose` endpoint
- Adapt API tests to consume `DiagnoseResponse`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f5b30e8c8832aabb6777f158051d3