### PR TITLE
Handle empty diagnosis in protocol lookup

### DIFF
--- a/services.py
+++ b/services.py
@@ -3,7 +3,10 @@ PROTOCOLS = {
     "диабет 1 типа": "insulin protocol",
 }
 
-def find_protocol_by_diagnosis(diagnosis: str) -> str | None:
+
+def find_protocol_by_diagnosis(diagnosis: str | None) -> str | None:
+    if not diagnosis:
+        return None
     diagnosis = diagnosis.strip().lower()
     return PROTOCOLS.get(diagnosis)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -14,3 +14,7 @@ def test_find_protocol_trims_whitespace():
     assert find_protocol_by_diagnosis("  Диабет 2 типа  ") == "standard protocol"
 
 
+def test_find_protocol_returns_none_for_missing_diagnosis():
+    assert find_protocol_by_diagnosis(None) is None
+
+


### PR DESCRIPTION
## Summary
- guard against missing diagnosis in `find_protocol_by_diagnosis`
- cover empty diagnosis with a unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68938cb4be7c832ab2fecf0a60e2606f