### PR TITLE
[gpt_parser] Handle non-object responses

### DIFF
--- a/diabetes/gpt_command_parser.py
+++ b/diabetes/gpt_command_parser.py
@@ -55,15 +55,19 @@ def _extract_first_json(text: str) -> dict | None:
     """Return the first JSON object found in *text* or ``None`` if absent."""
     decoder = json.JSONDecoder()
     idx = 0
-    while True:
-        start = text.find("{", idx)
-        if start == -1:
+    while idx < len(text):
+        match = re.search(r"[\[{]", text[idx:])
+        if not match:
             return None
+        start = idx + match.start()
         try:
             obj, end = decoder.raw_decode(text, start)
-            return obj
+            if isinstance(obj, dict):
+                return obj
+            idx = end
         except json.JSONDecodeError:
             idx = start + 1
+    return None
 
 
 async def parse_command(text: str, timeout: float = 10) -> dict | None:

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -76,6 +76,56 @@ async def test_parse_command_with_explanatory_text(monkeypatch):
     assert result == {"action": "add_entry", "time": "09:00", "fields": {}}
 
 
+@pytest.mark.asyncio
+async def test_parse_command_with_array_response(monkeypatch):
+    class FakeResponse:
+        choices = [
+            type(
+                "Choice",
+                (),
+                {"message": type("Msg", (), {"content": "[{\"action\":\"add_entry\"}]"})()},
+            )
+        ]
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda *args, **kwargs: FakeResponse()
+            )
+        )
+    )
+    monkeypatch.setattr(gpt_command_parser, "_get_client", lambda: fake_client)
+
+    result = await gpt_command_parser.parse_command("test")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_parse_command_with_scalar_response(monkeypatch):
+    class FakeResponse:
+        choices = [
+            type(
+                "Choice",
+                (),
+                {"message": type("Msg", (), {"content": "42"})()},
+            )
+        ]
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda *args, **kwargs: FakeResponse()
+            )
+        )
+    )
+    monkeypatch.setattr(gpt_command_parser, "_get_client", lambda: fake_client)
+
+    result = await gpt_command_parser.parse_command("test")
+
+    assert result is None
+
+
 @pytest.mark.parametrize(
     "token",
     [


### PR DESCRIPTION
## Summary
- ignore non-object JSON segments when extracting GPT command
- test parser behavior for array and scalar responses

## Testing
- `ruff check diabetes tests`
- `pytest tests/test_gpt_command_parser.py -q`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6893a7f6ff9c832a81f8be47f40848d9