### PR TITLE
[utils] Make parse_time_interval case-insensitive

### DIFF
--- a/diabetes/utils.py
+++ b/diabetes/utils.py
@@ -33,9 +33,10 @@ def parse_time_interval(value: str) -> time | timedelta:
     try:
         return datetime.strptime(value, "%H:%M").time()
     except ValueError:
-        match = re.fullmatch(r"(\d+)([hd])", value)
+        match = re.fullmatch(r"(\d+)([hd])", value, re.IGNORECASE)
         if match:
             num, unit = match.groups()
+            unit = unit.lower()
             amount = int(num)
             return timedelta(hours=amount) if unit == "h" else timedelta(days=amount)
         raise ValueError(INVALID_TIME_MSG)


### PR DESCRIPTION
## Summary
- support uppercase hour/day units in time interval parsing
- cover case-insensitive interval parsing in tests

## Testing
- `ruff check diabetes tests`
- `pytest tests/test_utils.py tests/test_parse_time_interval.py`

------
https://chatgpt.com/codex/tasks/task_e_6893afa83044832a8aba7fdc0dacdc20