### PR TITLE
feat: support per-user timezones

### DIFF
--- a/alembic/versions/d3e4f5a6b7c8_add_user_timezone.py
+++ b/alembic/versions/d3e4f5a6b7c8_add_user_timezone.py
@@ -1,0 +1,30 @@
+"""add timezone to users
+
+Revision ID: d3e4f5a6b7c8
+Revises: c0d1e2f3a4b5
+Create Date: 2025-09-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'd3e4f5a6b7c8'
+down_revision: Union[str, None] = 'c0d1e2f3a4b5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'users',
+        sa.Column('timezone', sa.String(), server_default='UTC', nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('users', 'timezone')

--- a/diabetes/db.py
+++ b/diabetes/db.py
@@ -25,6 +25,7 @@ class User(Base):
     thread_id = Column(String, nullable=False)
     onboarding_complete = Column(Boolean, default=False)
     plan = Column(String, default="free")
+    timezone = Column(String, default="UTC")  # IANA timezone identifier
     created_at = Column(TIMESTAMP(timezone=True), server_default=func.now())
 
 

--- a/tests/test_add_reminder_wizard.py
+++ b/tests/test_add_reminder_wizard.py
@@ -84,7 +84,9 @@ async def test_add_reminder_wizard_success(monkeypatch):
 
     cq = DummyCallbackQuery("rem_type:sugar", DummyMessage(), id="cb1")
     update2 = SimpleNamespace(callback_query=cq, effective_user=SimpleNamespace(id=1))
-    monkeypatch.setattr(handlers, "_schedule_with_next", lambda rem: ("⏰", "next 23:00"))
+    monkeypatch.setattr(
+        handlers, "_schedule_with_next", lambda rem, user=None: ("⏰", "next 23:00")
+    )
     state = await handlers.add_reminder_type(update2, context)
     assert state == handlers.REMINDER_TIME
 

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -79,6 +79,10 @@ async def test_onboarding_flow(monkeypatch):
 
     update.message.text = "6"
     state = await onboarding.onboarding_target(update, context)
+    assert state == onboarding.ONB_PROFILE_TZ
+
+    update.message.text = "Europe/Moscow"
+    state = await onboarding.onboarding_timezone(update, context)
     assert state == onboarding.ONB_DEMO
     assert message.photos
 


### PR DESCRIPTION
## Summary
- store timezone in User model and collect it during onboarding/profile setup
- schedule reminders using the user's ZoneInfo instead of UTC
- add Alembic migration and adjust tests for timezones

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6894283b3fec832abe41278260690f6b