### PR TITLE
[reporting] conditionally show XE

### DIFF
--- a/diabetes/reporting_handlers.py
+++ b/diabetes/reporting_handlers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import html
 import logging
 import time
 
@@ -28,15 +29,29 @@ HIGH_SUGAR_THRESHOLD = 13.0
 
 def render_entry(entry: Entry) -> str:
     """Render a single diary entry as HTML-formatted text."""
-    day_str = entry.event_time.strftime("%d.%m %H:%M")
-    sugar = entry.sugar_before if entry.sugar_before is not None else "—"
-    carbs = entry.carbs_g if entry.carbs_g is not None else "—"
-    xe = entry.xe if entry.xe is not None else "—"
-    dose = entry.dose if entry.dose is not None else "—"
+    day_str = html.escape(entry.event_time.strftime("%d.%m %H:%M"))
+    sugar = (
+        html.escape(str(entry.sugar_before))
+        if entry.sugar_before is not None
+        else "—"
+    )
+    dose = (
+        html.escape(str(entry.dose)) if entry.dose is not None else "—"
+    )
+
+    if entry.carbs_g is not None:
+        carbs_text = f"{html.escape(str(entry.carbs_g))} г"
+        if entry.xe is not None:
+            carbs_text += f" ({html.escape(str(entry.xe))} ХЕ)"
+    elif entry.xe is not None:
+        carbs_text = f"{html.escape(str(entry.xe))} ХЕ"
+    else:
+        carbs_text = "—"
+
     return (
         f"<b>{day_str}</b>\n"
         f"🍭 Сахар: <b>{sugar}</b>\n"
-        f"🍞 Углеводы: <b>{carbs} г ({xe} ХЕ)</b>\n"
+        f"🍞 Углеводы: <b>{carbs_text}</b>\n"
         f"💉 Доза: <b>{dose}</b>"
     )
 

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -96,7 +96,7 @@ async def test_history_view_buttons(monkeypatch):
         expected_texts.append(
             f"<b>{day_str}</b>\n"
             f"🍭 Сахар: <b>—</b>\n"
-            f"🍞 Углеводы: <b>— г (— ХЕ)</b>\n"
+            f"🍞 Углеводы: <b>—</b>\n"
             f"💉 Доза: <b>—</b>"
         )
     for (text, kwargs), expected in zip(message.replies[1:-1], expected_texts):

--- a/tests/test_render_entry.py
+++ b/tests/test_render_entry.py
@@ -1,0 +1,41 @@
+import datetime
+from types import SimpleNamespace
+
+from diabetes.reporting_handlers import render_entry
+
+
+def make_entry(**kwargs):
+    defaults = dict(
+        event_time=datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+        sugar_before=5.5,
+        carbs_g=None,
+        xe=None,
+        dose=1.0,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_render_entry_with_xe_and_carbs():
+    entry = make_entry(carbs_g=50, xe=4.1)
+    text = render_entry(entry)
+    assert "🍞 Углеводы: <b>50 г (4.1 ХЕ)</b>" in text
+
+
+def test_render_entry_with_xe_only():
+    entry = make_entry(carbs_g=None, xe=3.0)
+    text = render_entry(entry)
+    assert "🍞 Углеводы: <b>3.0 ХЕ</b>" in text
+
+
+def test_render_entry_without_xe():
+    entry = make_entry(carbs_g=30, xe=None)
+    text = render_entry(entry)
+    assert "🍞 Углеводы: <b>30 г</b>" in text
+    assert "ХЕ" not in text
+
+
+def test_render_entry_escapes_html():
+    entry = make_entry(dose="<script>")
+    text = render_entry(entry)
+    assert "&lt;script&gt;" in text


### PR DESCRIPTION
## Summary
- Render diary entries with XE only when provided and escape HTML
- Cover XE formatting and escaping with dedicated tests
- Adjust history view expectations for updated carbohydrate display

## Testing
- `ruff check diabetes tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68943406f958832aaddf616a33d1c75f