### PR TITLE
[handlers] Use placeholder when sugar is missing

### DIFF
--- a/diabetes/dose_handlers.py
+++ b/diabetes/dose_handlers.py
@@ -366,8 +366,9 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         dose = pending_entry.get("dose")
         xe_info = f", ХЕ {xe}" if xe is not None else ""
         dose_info = f", доза {dose} Ед." if dose is not None else ", доза —"
+        sugar_info = f"сахар {sugar} ммоль/л" if sugar is not None else "сахар —"
         await update.message.reply_text(
-            f"✅ Запись сохранена: сахар {sugar} ммоль/л{xe_info}{dose_info}",
+            f"✅ Запись сохранена: {sugar_info}{xe_info}{dose_info}",
             reply_markup=menu_keyboard,
         )
         return

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -58,3 +58,42 @@ async def test_entry_without_dose_has_no_unit(monkeypatch):
     assert "доза —" in text
     assert "Ед" not in text
 
+
+@pytest.mark.asyncio
+async def test_entry_without_sugar_has_placeholder(monkeypatch):
+    pending_entry = {
+        "telegram_id": 1,
+        "event_time": datetime.datetime.now(datetime.timezone.utc),
+    }
+    context = SimpleNamespace(
+        user_data={"pending_entry": pending_entry, "pending_fields": ["dose"]}
+    )
+    message = DummyMessage("5")
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def add(self, entry):
+            self.entry = entry
+
+    async def noop(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(dose_handlers, "SessionLocal", lambda: DummySession())
+    monkeypatch.setattr(dose_handlers, "commit_session", lambda session: True)
+    monkeypatch.setattr(dose_handlers, "check_alert", noop)
+    monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
+
+    await dose_handlers.freeform_handler(update, context)
+
+    assert not context.user_data
+    assert message.replies
+    text = message.replies[0]
+    assert "сахар —" in text
+    assert "ммоль/л" not in text
+


### PR DESCRIPTION
## Summary
- avoid showing `None` for missing sugar in `freeform_handler`
- cover missing-sugar scenario in tests

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689436204f98832aa27ea85caaf09c03