### PR TITLE
[config] enforce HTTPS for WEBAPP_URL

### DIFF
--- a/diabetes/config.py
+++ b/diabetes/config.py
@@ -40,3 +40,8 @@ DB_PASSWORD = os.getenv("DB_PASSWORD")
 # Optional directory containing custom fonts for PDF reports
 FONT_DIR = os.getenv("FONT_DIR")
 WEBAPP_URL = os.getenv("WEBAPP_URL")
+if not WEBAPP_URL:
+    logging.warning("WEBAPP_URL is not set; web app integration disabled")
+elif not WEBAPP_URL.startswith("https://"):
+    logging.warning("WEBAPP_URL must start with 'https://'; disabling web app integration")
+    WEBAPP_URL = None


### PR DESCRIPTION
## Summary
- validate `WEBAPP_URL` and ignore non-HTTPS URLs with a warning
- test config behavior for missing, invalid, and valid `WEBAPP_URL`

## Testing
- `ruff check diabetes tests`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_68947991832c832ab50158e168e6adb3