### PR TITLE
[ui] Add timezone WebApp button helper

### DIFF
--- a/diabetes/onboarding_handlers.py
+++ b/diabetes/onboarding_handlers.py
@@ -19,7 +19,6 @@ from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     Update,
-    WebAppInfo,
 )
 from telegram.ext import (
     CommandHandler,
@@ -31,10 +30,9 @@ from telegram.ext import (
 from diabetes.callbackquery_no_warn_handler import CallbackQueryNoWarnHandler
 
 from diabetes.db import SessionLocal, User, Profile
-from diabetes.ui import menu_keyboard
+from diabetes.ui import menu_keyboard, build_timezone_webapp_button
 from .common_handlers import commit_session
 from zoneinfo import ZoneInfo
-from diabetes.config import WEBAPP_URL
 
 logger = logging.getLogger(__name__)
 
@@ -181,13 +179,9 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             return ConversationHandler.END
 
     keyboard_buttons = []
-    if WEBAPP_URL:
-        keyboard_buttons.append(
-            InlineKeyboardButton(
-                "Определить автоматически",
-                web_app=WebAppInfo(WEBAPP_URL),
-            )
-        )
+    tz_button = build_timezone_webapp_button()
+    if tz_button:
+        keyboard_buttons.append(tz_button)
     keyboard_buttons.append(InlineKeyboardButton("Пропустить", callback_data="onb_skip"))
     await update.message.reply_text(
         "Введите ваш часовой пояс (например Europe/Moscow) или используйте кнопку ниже:",
@@ -207,12 +201,9 @@ async def onboarding_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE
         ZoneInfo(tz_name)
     except Exception:
         buttons = []
-        if WEBAPP_URL:
-            buttons.append(
-                InlineKeyboardButton(
-                    "Определить автоматически", web_app=WebAppInfo(WEBAPP_URL)
-                )
-            )
+        tz_button = build_timezone_webapp_button()
+        if tz_button:
+            buttons.append(tz_button)
         buttons.append(InlineKeyboardButton("Пропустить", callback_data="onb_skip"))
         await update.message.reply_text(
             "Введите корректный часовой пояс, например Europe/Moscow.",

--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import (
     CommandHandler,
     ContextTypes,
@@ -14,8 +14,7 @@ from diabetes.callbackquery_no_warn_handler import CallbackQueryNoWarnHandler
 
 from diabetes.db import SessionLocal, Profile, Alert, Reminder, User
 from diabetes.alert_handlers import evaluate_sugar
-from diabetes.ui import menu_keyboard, back_keyboard
-from diabetes.config import WEBAPP_URL
+from diabetes.ui import menu_keyboard, back_keyboard, build_timezone_webapp_button
 from .common_handlers import commit_session
 import diabetes.reminder_handlers as reminder_handlers
 from zoneinfo import ZoneInfo
@@ -225,17 +224,9 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         "Введите ваш часовой пояс (например Europe/Moscow):",
         reply_markup=back_keyboard,
     )
-    if WEBAPP_URL:
-        keyboard = InlineKeyboardMarkup(
-            [
-                [
-                    InlineKeyboardButton(
-                        "Определить автоматически",
-                        web_app=WebAppInfo(WEBAPP_URL),
-                    )
-                ]
-            ]
-        )
+    button = build_timezone_webapp_button()
+    if button:
+        keyboard = InlineKeyboardMarkup([[button]])
         await query.message.reply_text(
             "Можно определить автоматически:", reply_markup=keyboard
         )
@@ -258,12 +249,9 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
             "Некорректный часовой пояс. Пример: Europe/Moscow",
             reply_markup=back_keyboard,
         )
-        if WEBAPP_URL:
-            keyboard = InlineKeyboardMarkup(
-                [
-                    [InlineKeyboardButton("Определить автоматически", web_app=WebAppInfo(WEBAPP_URL))]
-                ]
-            )
+        button = build_timezone_webapp_button()
+        if button:
+            keyboard = InlineKeyboardMarkup([[button]])
             await update.message.reply_text(
                 "Можно определить автоматически:", reply_markup=keyboard
             )

--- a/diabetes/ui.py
+++ b/diabetes/ui.py
@@ -12,7 +12,9 @@ from telegram import (
     InlineKeyboardButton,
     ReplyKeyboardMarkup,
     KeyboardButton,
+    WebAppInfo,
 )
+from diabetes.config import WEBAPP_URL
 
 __all__ = (
     "menu_keyboard",
@@ -20,6 +22,7 @@ __all__ = (
     "sugar_keyboard",
     "confirm_keyboard",
     "back_keyboard",
+    "build_timezone_webapp_button",
 )
 
 # ─────────────── Reply-клавиатуры (отображаются на экране чата) ───────────────
@@ -88,3 +91,21 @@ def confirm_keyboard(back_cb: str | None = None) -> InlineKeyboardMarkup:
             [InlineKeyboardButton("🔙 Назад", callback_data=back_cb)]
         )
     return InlineKeyboardMarkup(rows)
+
+
+def build_timezone_webapp_button() -> InlineKeyboardButton | None:
+    """Create a WebApp button for timezone detection if configured.
+
+    Returns
+    -------
+    InlineKeyboardButton | None
+        Button instance when ``WEBAPP_URL`` is set and valid, otherwise ``None``.
+    """
+
+    if not WEBAPP_URL:
+        return None
+
+    return InlineKeyboardButton(
+        "Определить автоматически",
+        web_app=WebAppInfo(WEBAPP_URL),
+    )


### PR DESCRIPTION
## Summary
- add `build_timezone_webapp_button` helper to construct timezone WebApp button when `WEBAPP_URL` is configured
- use helper in profile and onboarding handlers, only adding button when available

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68947f099bb8832ab9c59c2effcf8454