### PR TITLE
[webapp] add profile web form

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -277,6 +277,7 @@ def register_handlers(app: Application) -> None:
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
     app.add_handler(profile_handlers.profile_conv)
+    app.add_handler(profile_handlers.profile_webapp_handler)
     app.add_handler(dose_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(CommandHandler("cancel", dose_handlers.dose_cancel))

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Profile</title>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const form = document.getElementById('profile-form');
+            form.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                const data = {
+                    icr: form.icr.value,
+                    cf: form.cf.value,
+                    target: form.target.value,
+                    low: form.low.value,
+                    high: form.high.value,
+                };
+                try {
+                    const resp = await fetch(form.action, {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify(data)
+                    });
+                    if (resp.ok && window.Telegram && Telegram.WebApp) {
+                        Telegram.WebApp.ready();
+                        Telegram.WebApp.sendData(JSON.stringify(data));
+                    }
+                } catch (err) {
+                    console.error('Failed to submit profile', err);
+                }
+            });
+        });
+    </script>
+</head>
+<body>
+<form id="profile-form" action="/profile" method="post">
+    <label>ICR: <input name="icr" type="number" step="any" required></label><br>
+    <label>CF: <input name="cf" type="number" step="any" required></label><br>
+    <label>target: <input name="target" type="number" step="any" required></label><br>
+    <label>low: <input name="low" type="number" step="any" required></label><br>
+    <label>high: <input name="high" type="number" step="any" required></label><br>
+    <button type="submit">Save</button>
+</form>
+</body>
+</html>

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import FileResponse
 
 app = FastAPI()
@@ -15,6 +15,19 @@ BASE_DIR = Path(__file__).parent
 async def index() -> FileResponse:  # pragma: no cover - trivial
     """Return the main page."""
     return FileResponse(BASE_DIR / "index.html")
+
+
+@app.get("/profile")
+async def profile() -> FileResponse:  # pragma: no cover - trivial
+    """Return the profile form page."""
+    return FileResponse(BASE_DIR / "profile.html")
+
+
+@app.post("/profile")
+async def profile_post(request: Request) -> dict:  # pragma: no cover - simple
+    """Accept submitted profile data."""
+    await request.json()
+    return {"status": "ok"}
 
 
 if __name__ == "__main__":  # pragma: no cover - manual start


### PR DESCRIPTION
## Summary
- create profile web app page to collect ICR, CF, target and BG ranges
- serve profile form via FastAPI and expose POST handler
- hook up Telegram WebApp button and process submitted profile data

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6894b656231c832aae5193f6d9954084