### PR TITLE
[webapp] Add reminder management page and handlers

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -284,7 +284,8 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("help", help_command))
     app.add_handler(CommandHandler("gpt", dose_handlers.chat_with_gpt))
     app.add_handler(CommandHandler("reminders", reminder_handlers.reminders_list))
-    app.add_handler(reminder_handlers.add_reminder_conv)
+    app.add_handler(reminder_handlers.reminder_action_handler)
+    app.add_handler(reminder_handlers.reminder_webapp_handler)
     app.add_handler(CommandHandler("delreminder", reminder_handlers.delete_reminder))
     app.add_handler(CommandHandler("alertstats", alert_handlers.alert_stats))
     app.add_handler(CommandHandler("hypoalert", security_handlers.hypo_alert_faq))
@@ -317,8 +318,6 @@ def register_handlers(app: Application) -> None:
             filters.Regex("^🆘 SOS контакт$"), sos_handlers.sos_contact_start
         )
     )
-    # Reminder edit conversation should run before generic free-form handler
-    app.add_handler(reminder_handlers.reminder_edit_conv)
     app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, dose_handlers.freeform_handler)
     )

--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -384,7 +384,14 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
             await sos_handlers.sos_contact_start(update.callback_query, context)
         elif action == "add":
-            await reminder_handlers.add_reminder_start(update, context)
+            if WEBAPP_URL:
+                button = InlineKeyboardButton(
+                    "📝 Новое", web_app=WebAppInfo(f"{WEBAPP_URL}/reminder")
+                )
+                keyboard = InlineKeyboardMarkup([[button]])
+                await query.message.reply_text(
+                    "Создать напоминание:", reply_markup=keyboard
+                )
         elif action == "del":
             await reminder_handlers.delete_reminder(update, context)
 

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -9,7 +9,6 @@ os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import diabetes.openai_utils as openai_utils  # noqa: F401
 from diabetes import (
     dose_handlers,
-    reminder_handlers,
     profile_handlers,
     onboarding_handlers,
     sos_handlers,
@@ -35,18 +34,6 @@ async def _exercise(handler):
     assert message.replies[0] == "Отменено."
     assert any("фото" in r.lower() for r in message.replies[1:])
     assert context.user_data == {}
-
-
-@pytest.mark.asyncio
-async def test_add_reminder_conv_photo_fallback():
-    handler = next(
-        h
-        for h in reminder_handlers.add_reminder_conv.fallbacks
-        if isinstance(h, MessageHandler)
-        and getattr(getattr(h, "filters", None), "pattern", None).pattern
-        == "^📷 Фото еды$"
-    )
-    await _exercise(handler)
 
 
 @pytest.mark.asyncio

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -202,23 +202,20 @@ async def test_profile_security_add_delete_calls_handlers(monkeypatch):
         session.add(Profile(telegram_id=1, icr=10, cf=2, target_bg=6))
         session.commit()
 
-    called = {"add": False, "del": False}
-
-    async def fake_add(update, context):
-        called["add"] = True
+    called = {"del": False}
 
     async def fake_del(update, context):
         called["del"] = True
 
-    monkeypatch.setattr(reminder_handlers, "add_reminder_start", fake_add)
     monkeypatch.setattr(reminder_handlers, "delete_reminder", fake_del)
 
+    monkeypatch.setattr(handlers, "WEBAPP_URL", "http://example")
     query_add = DummyQuery("profile_security:add")
     update_add = SimpleNamespace(callback_query=query_add, effective_user=SimpleNamespace(id=1))
     context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))
 
     await handlers.profile_security(update_add, context)
-    assert called["add"] is True
+    assert query_add.message.texts[-1] == "Создать напоминание:"
 
     query_del = DummyQuery("profile_security:del")
     update_del = SimpleNamespace(callback_query=query_del, effective_user=SimpleNamespace(id=1))

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -39,22 +39,16 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     assert reporting_handlers.history_view in callbacks
     assert dose_handlers.chat_with_gpt in callbacks
     assert security_handlers.hypo_alert_faq in callbacks
-    # Reminder edit conversation should be registered
-    reminder_convs = [
-        h
+    # Reminder handlers should be registered
+    assert any(
+        isinstance(h, CallbackQueryHandler)
+        and h.callback is reminder_handlers.reminder_action_cb
         for h in handlers
-        if isinstance(h, ConversationHandler)
-        and any(
-            isinstance(ep, CallbackQueryHandler)
-            and ep.callback is reminder_handlers.reminder_action_cb
-            for ep in h.entry_points
-        )
-    ]
-    assert reminder_convs
+    )
     assert any(
         isinstance(h, MessageHandler)
-        and h.callback is reminder_handlers.reminder_edit_reply
-        for h in reminder_convs[0].states.get(reminder_handlers.REM_EDIT_AWAIT_INPUT, [])
+        and h.callback is reminder_handlers.reminder_webapp_save
+        for h in handlers
     )
 
     onb_conv = [

--- a/webapp/reminder.html
+++ b/webapp/reminder.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Reminder</title>
+    <script>
+        document.addEventListener('DOMContentLoaded', async () => {
+            const form = document.getElementById('reminder-form');
+            const urlParams = new URLSearchParams(window.location.search);
+            const id = urlParams.get('id');
+            if (id) {
+                try {
+                    const resp = await fetch(`/reminders?id=${id}`);
+                    if (resp.ok) {
+                        const data = await resp.json();
+                        form.rem_id.value = data.id || '';
+                        form.rem_type.value = data.type || '';
+                        form.value.value = data.time || data.interval || '';
+                    }
+                } catch (err) {
+                    console.error('Failed to load reminder', err);
+                }
+            }
+            form.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                const payload = {
+                    id: form.rem_id.value || null,
+                    type: form.rem_type.value,
+                    value: form.value.value
+                };
+                try {
+                    const resp = await fetch(form.action, {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify(payload)
+                    });
+                    if (resp.ok && window.Telegram && Telegram.WebApp) {
+                        Telegram.WebApp.ready();
+                        Telegram.WebApp.sendData(JSON.stringify(payload));
+                    }
+                } catch (err) {
+                    console.error('Failed to submit reminder', err);
+                }
+            });
+        });
+    </script>
+</head>
+<body>
+<form id="reminder-form" action="/reminders" method="post">
+    <input type="hidden" name="rem_id">
+    <label>Type:
+        <select name="rem_type">
+            <option value="sugar">Sugar</option>
+            <option value="long_insulin">Long insulin</option>
+            <option value="medicine">Medicine</option>
+            <option value="xe_after">XE after meal</option>
+        </select>
+    </label><br>
+    <label>Time or interval: <input name="value" type="text" required></label><br>
+    <button type="submit">Save</button>
+</form>
+</body>
+</html>

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -9,6 +9,8 @@ from fastapi.responses import FileResponse
 
 app = FastAPI()
 BASE_DIR = Path(__file__).parent
+REMINDERS: dict[int, dict] = {}
+NEXT_ID = 1
 
 
 @app.get("/")
@@ -28,6 +30,31 @@ async def profile_post(request: Request) -> dict:  # pragma: no cover - simple
     """Accept submitted profile data."""
     await request.json()
     return {"status": "ok"}
+
+
+@app.get("/reminder")
+async def reminder_form() -> FileResponse:  # pragma: no cover - trivial
+    """Return the reminder form page."""
+    return FileResponse(BASE_DIR / "reminder.html")
+
+
+@app.get("/reminders")
+async def reminders_get(id: int | None = None) -> dict | list[dict]:  # pragma: no cover - simple
+    """Return stored reminders (in-memory demo store)."""
+    if id is None:
+        return list(REMINDERS.values())
+    return REMINDERS.get(id, {})
+
+
+@app.post("/reminders")
+async def reminders_post(request: Request) -> dict:  # pragma: no cover - simple
+    """Save reminder data to demo store."""
+    global NEXT_ID
+    data = await request.json()
+    rid = data.get("id") or NEXT_ID
+    NEXT_ID = max(NEXT_ID, rid + 1)
+    REMINDERS[int(rid)] = {"id": int(rid), **data}
+    return {"status": "ok", "id": int(rid)}
 
 
 if __name__ == "__main__":  # pragma: no cover - manual start


### PR DESCRIPTION
## Summary
- add WebApp page for creating or editing reminders
- serve reminder form with FastAPI routes
- handle WebApp reminder data in bot and register new handlers

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6894c0a3bcf0832ab74a419cb9c7d09b