### PR TITLE
[webapp] validate reminder IDs

### DIFF
--- a/tests/test_webapp_server.py
+++ b/tests/test_webapp_server.py
@@ -1,0 +1,39 @@
+"""Tests for minimal FastAPI webapp used for reminders."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import webapp.server as server
+
+
+client = TestClient(server.app)
+
+
+def setup_function() -> None:
+    """Reset in-memory state before each test."""
+    server.REMINDERS.clear()
+    server.NEXT_ID = 1
+
+
+def test_reminders_post_accepts_str_and_int_ids() -> None:
+    """Posting reminders with string or int IDs stores numeric IDs."""
+    response = client.post("/reminders", json={"id": 5, "text": "foo"})
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "id": 5}
+    assert server.REMINDERS[5]["id"] == 5
+
+    response = client.post("/reminders", json={"id": "6", "text": "bar"})
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "id": 6}
+    assert server.REMINDERS[6]["id"] == 6
+    assert server.NEXT_ID == 7
+
+
+@pytest.mark.parametrize("rid", [-1, "-1"])
+def test_reminders_post_rejects_negative_id(rid: int | str) -> None:
+    """Posting a negative ID should return a validation error."""
+    response = client.post("/reminders", json={"id": rid, "text": "oops"})
+    assert response.status_code == 400
+    assert server.REMINDERS == {}
+    assert server.NEXT_ID == 1
+


### PR DESCRIPTION
## Summary
- validate and normalize reminder IDs in webapp server
- cover reminder ID handling with FastAPI tests

## Testing
- `ruff check webapp tests`
- `pytest tests/test_webapp_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6894c97a4da0832a8b3809ba14c4247f