### PR TITLE
[gpt_client] Remove image only after successful upload

### DIFF
--- a/diabetes/gpt_client.py
+++ b/diabetes/gpt_client.py
@@ -71,18 +71,20 @@ def send_message(
         try:
             with open(image_path, "rb") as f:
                 file = _get_client().files.create(file=f, purpose="vision")
-            logger.info("[OpenAI] Uploaded image %s, file_id=%s", image_path, file.id)
-            content_block = [
-                {"type": "image_file", "image_file": {"file_id": file.id}},
-                text_block,
-            ]
         except OSError as exc:
             logger.exception("[OpenAI] Failed to read %s: %s", image_path, exc)
             raise
         except OpenAIError as exc:
             logger.exception("[OpenAI] Failed to upload %s: %s", image_path, exc)
             raise
-        finally:
+        else:
+            logger.info(
+                "[OpenAI] Uploaded image %s, file_id=%s", image_path, file.id
+            )
+            content_block = [
+                {"type": "image_file", "image_file": {"file_id": file.id}},
+                text_block,
+            ]
             if not keep_image:
                 try:
                     os.remove(image_path)

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -73,7 +73,7 @@ def test_create_thread_openaierror(monkeypatch, caplog):
     assert any("Failed to create thread" in r.message for r in caplog.records)
 
 
-def test_send_message_upload_error_removes_file(tmp_path, monkeypatch):
+def test_send_message_upload_error_keeps_file(tmp_path, monkeypatch):
     img = tmp_path / "img.jpg"
     img.write_bytes(b"data")
 
@@ -86,7 +86,7 @@ def test_send_message_upload_error_removes_file(tmp_path, monkeypatch):
     with pytest.raises(OpenAIError):
         gpt_client.send_message(thread_id="t", image_path=str(img))
 
-    assert not img.exists()
+    assert img.exists()
 
 
 def test_send_message_empty_string_preserved(tmp_path, monkeypatch):
@@ -114,5 +114,5 @@ def test_send_message_empty_string_preserved(tmp_path, monkeypatch):
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
 
     gpt_client.send_message(thread_id="t", content="", image_path=str(img))
-
     assert captured["content"][1]["text"] == ""
+    assert not img.exists()


### PR DESCRIPTION
## Summary
- Avoid deleting images when the OpenAI upload fails
- Add coverage to ensure images persist on upload errors
- Ensure successful uploads delete temporary files

## Testing
- `ruff check diabetes tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894e02d5814832abe1c42e0760d76ca