### PR TITLE
[webapp] remove deprecated Pydantic dict usage

### DIFF
--- a/tests/test_webapp_server.py
+++ b/tests/test_webapp_server.py
@@ -38,7 +38,7 @@ def test_reminders_post_accepts_str_and_int_ids() -> None:
 def test_profile_post_rejects_invalid_json() -> None:
     """Posting malformed JSON to /profile returns an error."""
     response = client.post(
-        "/profile", data="{bad", headers={"Content-Type": "application/json"}
+        "/profile", content="{bad", headers={"Content-Type": "application/json"}
     )
     assert response.status_code == 400
 
@@ -54,7 +54,7 @@ def test_reminders_post_rejects_negative_id(rid: int | str) -> None:
 def test_reminders_post_rejects_invalid_json() -> None:
     """Malformed JSON for /reminders should return an error and keep state empty."""
     response = client.post(
-        "/reminders", data="{bad", headers={"Content-Type": "application/json"}
+        "/reminders", content="{bad", headers={"Content-Type": "application/json"}
     )
     assert response.status_code == 400
     assert client.get("/reminders").json() == []

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -106,7 +106,7 @@ async def reminders_post(request: Request) -> dict:  # pragma: no cover - simple
     rid = reminder.id if reminder.id is not None else max(store.keys(), default=0) + 1
     if rid < 0:
         raise HTTPException(status_code=400, detail="id must be non-negative")
-    store[rid] = {**reminder.dict(exclude_none=True), "id": rid}
+    store[rid] = {**reminder.model_dump(exclude_none=True), "id": rid}
     _write_reminders(store)
     return {"status": "ok", "id": rid}
 


### PR DESCRIPTION
## Summary
- use `model_dump` instead of deprecated `dict` when persisting reminders
- adjust webapp server tests to avoid httpx deprecation warnings

## Testing
- `ruff check webapp/server.py tests/test_webapp_server.py`
- `pytest tests/test_webapp_server.py -Werror`


------
https://chatgpt.com/codex/tasks/task_e_6894e15fd07c832a8fbb40ff8546fb0e