### PR TITLE
[reporting] sort entries chronologically for sugar plot

### DIFF
--- a/diabetes/reporting.py
+++ b/diabetes/reporting.py
@@ -59,8 +59,12 @@ def make_sugar_plot(entries, period_label):
     Генерирует график сахара за период. Возвращает BytesIO с PNG.
     Если данных нет, возвращает изображение с сообщением об отсутствии данных.
     """
-    times = [e.event_time for e in entries if e.sugar_before is not None]
-    sugars_plot = [e.sugar_before for e in entries if e.sugar_before is not None]
+    entries_sorted = sorted(
+        (e for e in entries if e.sugar_before is not None),
+        key=lambda e: e.event_time,
+    )
+    times = [e.event_time for e in entries_sorted]
+    sugars_plot = [e.sugar_before for e in entries_sorted]
 
     if not sugars_plot:
         logging.info("No sugar data available for %s", period_label)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -5,6 +5,7 @@ import io
 import os
 from types import SimpleNamespace
 
+import matplotlib.pyplot as plt
 import pytest
 from pypdf import PdfReader
 from sqlalchemy import create_engine
@@ -45,6 +46,39 @@ def test_make_sugar_plot():
     assert hasattr(buf, 'read')
     buf.seek(0)
     assert len(buf.read()) > 1000  # есть содержимое
+
+
+def test_make_sugar_plot_sorts_entries(monkeypatch):
+    entries = [
+        DummyEntry(
+            datetime.datetime(2025, 7, 1, 14, tzinfo=datetime.timezone.utc),
+            9.0,
+            50,
+            4.1,
+            8,
+        ),
+        DummyEntry(
+            datetime.datetime(2025, 7, 1, 9, tzinfo=datetime.timezone.utc),
+            7.0,
+            40,
+            3.3,
+            6,
+        ),
+    ]
+    captured = {}
+
+    def fake_plot(x, y, **kwargs):
+        captured["x"] = x
+        captured["y"] = y
+
+    monkeypatch.setattr(plt, "plot", fake_plot)
+    make_sugar_plot(entries, "период")
+
+    assert captured["x"] == [
+        datetime.datetime(2025, 7, 1, 9, tzinfo=datetime.timezone.utc),
+        datetime.datetime(2025, 7, 1, 14, tzinfo=datetime.timezone.utc),
+    ]
+    assert captured["y"] == [7.0, 9.0]
 
 
 def test_make_sugar_plot_no_data():


### PR DESCRIPTION
## Summary
- sort sugar plot entries by event time before plotting
- test plotting of unsorted entries to ensure chronological order

## Testing
- `ruff check diabetes tests`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_6894e2d977dc832ab9649fa422bf98de