### PR TITLE
[tests] Use binary content for invalid JSON tests

### DIFF
--- a/tests/test_webapp_server.py
+++ b/tests/test_webapp_server.py
@@ -38,9 +38,12 @@ def test_reminders_post_accepts_str_and_int_ids() -> None:
 def test_profile_post_rejects_invalid_json() -> None:
     """Posting malformed JSON to /profile returns an error."""
     response = client.post(
-        "/profile", content="{bad", headers={"Content-Type": "application/json"}
+        "/profile",
+        content=b"{bad",
+        headers={"Content-Type": "application/json"},
     )
     assert response.status_code == 400
+    assert response.json() == {"detail": "invalid JSON format"}
 
 
 @pytest.mark.parametrize("rid", [-1, "-1"])
@@ -54,7 +57,10 @@ def test_reminders_post_rejects_negative_id(rid: int | str) -> None:
 def test_reminders_post_rejects_invalid_json() -> None:
     """Malformed JSON for /reminders should return an error and keep state empty."""
     response = client.post(
-        "/reminders", content="{bad", headers={"Content-Type": "application/json"}
+        "/reminders",
+        content=b"{bad",
+        headers={"Content-Type": "application/json"},
     )
     assert response.status_code == 400
+    assert response.json() == {"detail": "invalid JSON format"}
     assert client.get("/reminders").json() == []


### PR DESCRIPTION
## Summary
- Use byte-string `content` for malformed JSON payloads in webapp server tests
- Assert error responses include detail messages

## Testing
- `ruff check diabetes tests/test_webapp_server.py`
- `pytest tests/test_webapp_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6894e325b0b0832a937a2753e5cc022f