### PR TITLE
[webapp] Rename reminder type field

### DIFF
--- a/webapp/reminder.html
+++ b/webapp/reminder.html
@@ -17,7 +17,7 @@
                     if (resp.ok) {
                         const data = await resp.json();
                         form.rem_id.value = data.id || '';
-                        form.rem_type.value = data.type || data.rem_type || '';
+                        form.type.value = data.type || data.rem_type || '';
                         let value = '';
                         if (data.value !== undefined) {
                             value = String(data.value);
@@ -36,7 +36,7 @@
                 e.preventDefault();
                 const payload = {
                     id: form.rem_id.value || null,
-                    type: form.rem_type.value
+                    type: form.type.value
                 };
                 let raw = form.value.value.trim();
                 if (payload.type === 'xe_after') {
@@ -90,7 +90,7 @@
 <form id="reminder-form" action="/reminders" method="post">
     <input type="hidden" name="rem_id">
     <label>Type:
-        <select name="rem_type">
+        <select name="type">
             <option value="sugar">Sugar</option>
             <option value="long_insulin">Long insulin</option>
             <option value="medicine">Medicine</option>

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -53,7 +53,7 @@ class ReminderSchema(BaseModel):
     """Schema for reminder data."""
 
     id: int | None = None
-    rem_type: str | None = None
+    type: str | None = None
     value: str | None = None
     text: str | None = None
 
@@ -112,6 +112,10 @@ async def reminders_post(request: Request) -> dict:  # pragma: no cover - simple
         raise HTTPException(status_code=400, detail="invalid data") from exc
 
     store = await _read_reminders()
+    # migrate old reminders using "rem_type" to unified "type" key
+    for item in store.values():
+        if "rem_type" in item and "type" not in item:
+            item["type"] = item.pop("rem_type")
     rid = reminder.id if reminder.id is not None else max(store.keys(), default=0) + 1
     if rid < 0:
         raise HTTPException(status_code=400, detail="id must be non-negative")


### PR DESCRIPTION
## Summary
- rename `rem_type` to `type` in webapp server
- migrate existing reminders to new field name
- update reminder page to read and submit the new field

## Testing
- `ruff check webapp diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6894efd56208832a93f72232a88d5e51