### PR TITLE
[reminders] Validate reminder value format

### DIFF
--- a/webapp/reminder.html
+++ b/webapp/reminder.html
@@ -62,12 +62,18 @@
                         }
                         payload.value = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
                     } else {
-                        const num = parseInt(raw, 10);
-                        if (Number.isNaN(num)) {
-                            alert('Введите число');
+                        const hMatch = raw.match(/^(\d+)h$/i);
+                        if (hMatch) {
+                            const num = parseInt(hMatch[1], 10);
+                            if (Number.isNaN(num)) {
+                                alert('Введите число');
+                                return;
+                            }
+                            payload.value = `${num}h`;
+                        } else {
+                            alert('Формат должен быть HH:MM или число часов с h');
                             return;
                         }
-                        payload.value = `${num}h`;
                     }
                 }
                 try {
@@ -97,7 +103,7 @@
             <option value="xe_after">XE after meal</option>
         </select>
     </label><br>
-    <label>Time or interval: <input name="value" type="text" required></label><br>
+    <label>Time or interval: <input name="value" type="text" required pattern="([0-9]{1,2}:[0-9]{2}|[0-9]+[hH])" title="HH:MM or 3h"></label><br>
     <button type="submit">Save</button>
 </form>
 </body>


### PR DESCRIPTION
## Summary
- log raw reminder value before parsing and enforce HH:MM or hours+h format
- show clear error when format invalid
- extend webapp validation with regex and input pattern

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6894f1a563b0832aad904da657ce94b5