### PR TITLE
[webapp] Expand on load and add viewport meta tags

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -2,12 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Timezone</title>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
             if (window.Telegram && Telegram.WebApp) {
                 Telegram.WebApp.ready();
+                Telegram.WebApp.expand();
                 Telegram.WebApp.sendData(tz);
             }
         });

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -2,11 +2,13 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Profile</title>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             if (window.Telegram && Telegram.WebApp) {
                 Telegram.WebApp.ready();
+                Telegram.WebApp.expand();
             }
             const form = document.getElementById('profile-form');
             form.addEventListener('submit', async (e) => {

--- a/webapp/reminder.html
+++ b/webapp/reminder.html
@@ -2,11 +2,13 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Reminder</title>
     <script>
         document.addEventListener('DOMContentLoaded', async () => {
             if (window.Telegram && Telegram.WebApp) {
                 Telegram.WebApp.ready();
+                Telegram.WebApp.expand();
             }
             const form = document.getElementById('reminder-form');
             const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- Add viewport meta tag to webapp pages to ensure proper mobile scaling
- Expand Telegram WebApp after ready in index, reminder and profile pages

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68951c6cec2c832a9b31074dccdb5de5