### PR TITLE
[webapp] Add shared stylesheet and form layout

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <link rel="stylesheet" href="/style.css">
     <title>Timezone</title>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <link rel="stylesheet" href="/style.css">
     <title>Profile</title>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
@@ -45,11 +46,26 @@
 </head>
 <body>
 <form id="profile-form" action="/profile" method="post">
-    <label>ICR: <input name="icr" type="number" step="any" required></label><br>
-    <label>CF: <input name="cf" type="number" step="any" required></label><br>
-    <label>target: <input name="target" type="number" step="any" required></label><br>
-    <label>low: <input name="low" type="number" step="any" required></label><br>
-    <label>high: <input name="high" type="number" step="any" required></label><br>
+    <div class="form-row">
+        <label for="icr">ICR:</label>
+        <input id="icr" name="icr" type="number" step="any" required>
+    </div>
+    <div class="form-row">
+        <label for="cf">CF:</label>
+        <input id="cf" name="cf" type="number" step="any" required>
+    </div>
+    <div class="form-row">
+        <label for="target">target:</label>
+        <input id="target" name="target" type="number" step="any" required>
+    </div>
+    <div class="form-row">
+        <label for="low">low:</label>
+        <input id="low" name="low" type="number" step="any" required>
+    </div>
+    <div class="form-row">
+        <label for="high">high:</label>
+        <input id="high" name="high" type="number" step="any" required>
+    </div>
     <button type="submit">Save</button>
 </form>
 </body>

--- a/webapp/reminder.html
+++ b/webapp/reminder.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <link rel="stylesheet" href="/style.css">
     <title>Reminder</title>
     <script>
         document.addEventListener('DOMContentLoaded', async () => {
@@ -97,15 +98,19 @@
 <body>
 <form id="reminder-form" action="/reminders" method="post">
     <input type="hidden" name="rem_id">
-    <label>Type:
-        <select name="type">
+    <div class="form-row">
+        <label for="type">Type:</label>
+        <select id="type" name="type">
             <option value="sugar">Sugar</option>
             <option value="long_insulin">Long insulin</option>
             <option value="medicine">Medicine</option>
             <option value="xe_after">XE after meal</option>
         </select>
-    </label><br>
-    <label>Time or interval: <input name="value" type="text" required pattern="([0-9]{1,2}:[0-9]{2}|[0-9]+[hH])" title="HH:MM or 3h"></label><br>
+    </div>
+    <div class="form-row">
+        <label for="value">Time or interval:</label>
+        <input id="value" name="value" type="text" required pattern="([0-9]{1,2}:[0-9]{2}|[0-9]+[hH])" title="HH:MM or 3h">
+    </div>
     <button type="submit">Save</button>
 </form>
 </body>

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -90,6 +90,12 @@ async def reminder_form() -> FileResponse:  # pragma: no cover - trivial
     return FileResponse(BASE_DIR / "reminder.html")
 
 
+@app.get("/style.css")
+async def style_css() -> FileResponse:  # pragma: no cover - trivial
+    """Return the shared stylesheet."""
+    return FileResponse(BASE_DIR / "style.css")
+
+
 @app.get("/reminders")
 async def reminders_get(id: int | None = None) -> dict | list[dict]:  # pragma: no cover - simple
     """Return stored reminders from JSON file."""

--- a/webapp/style.css
+++ b/webapp/style.css
@@ -1,0 +1,30 @@
+body {
+    font-family: Arial, sans-serif;
+    font-size: 18px;
+    margin: 20px;
+}
+
+form {
+    max-width: 400px;
+    margin: 0 auto;
+}
+
+.form-row {
+    margin-bottom: 15px;
+}
+
+.form-row label {
+    display: block;
+    margin-bottom: 5px;
+}
+
+input,
+select,
+button {
+    padding: 8px;
+    font-size: 1rem;
+}
+
+button {
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Add shared stylesheet for webapp with improved base font, spacing, and controls
- Link stylesheet in all HTML pages and replace `<br>` tags with semantic `.form-row` divs
- Serve stylesheet via FastAPI endpoint

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68951e0e963c832a8d30334e1b20edf3