### PR TITLE
[webapp] Use Telegram theme variables in CSS

### DIFF
--- a/webapp/style.css
+++ b/webapp/style.css
@@ -1,7 +1,13 @@
+:root {
+    color-scheme: light dark;
+}
+
 body {
     font-family: Arial, sans-serif;
     font-size: 18px;
     margin: 20px;
+    background-color: var(--tg-theme-bg-color);
+    color: var(--tg-theme-text-color);
 }
 
 form {
@@ -23,8 +29,14 @@ select,
 button {
     padding: 8px;
     font-size: 1rem;
+    color: inherit;
+    background-color: var(--tg-theme-bg-color);
+    border: 1px solid var(--tg-theme-text-color);
 }
 
 button {
     cursor: pointer;
+    background-color: var(--tg-theme-button-color);
+    color: var(--tg-theme-button-text-color, var(--tg-theme-bg-color));
+    border: none;
 }


### PR DESCRIPTION
## Summary
- apply Telegram WebApp theme variables for background, text, and button styles
- ensure form controls inherit theme colors across light and dark modes

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68951fa724bc832a80651be326ae7604