### PR TITLE
[webapp] add fallbacks for Telegram CSS variables

### DIFF
--- a/webapp/style.css
+++ b/webapp/style.css
@@ -6,8 +6,8 @@ body {
     font-family: Arial, sans-serif;
     font-size: 18px;
     margin: 20px;
-    background-color: var(--tg-theme-bg-color);
-    color: var(--tg-theme-text-color);
+    background-color: var(--tg-theme-bg-color, #ffffff);
+    color: var(--tg-theme-text-color, #000000);
 }
 
 form {
@@ -30,14 +30,14 @@ button {
     padding: 8px;
     font-size: 1rem;
     color: inherit;
-    background-color: var(--tg-theme-bg-color);
-    border: 1px solid var(--tg-theme-text-color);
+    background-color: var(--tg-theme-bg-color, #ffffff);
+    border: 1px solid var(--tg-theme-text-color, #000000);
 }
 
 button {
     cursor: pointer;
-    background-color: var(--tg-theme-button-color);
-    color: var(--tg-theme-button-text-color, var(--tg-theme-bg-color));
+    background-color: var(--tg-theme-button-color, #2481cc);
+    color: var(--tg-theme-button-text-color, var(--tg-theme-bg-color, #ffffff));
     border: none;
 }
 .hint {


### PR DESCRIPTION
## Summary
- add default color and background fallbacks for webapp body
- provide fallback values for input and button Telegram theme variables

## Testing
- `ruff check diabetes tests`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_689585a8d3e8832a83e72e4996f617db