### PR TITLE
[webapp] Use theme hint color for dark/light modes

### DIFF
--- a/webapp/style.css
+++ b/webapp/style.css
@@ -44,5 +44,5 @@ button {
     display: block;
     margin-top: 4px;
     font-size: 0.9rem;
-    color: gray;
+    color: var(--tg-theme-hint-color, gray);
 }


### PR DESCRIPTION
## Summary
- use Telegram theme hint color variable for `.hint` text

## Testing
- `ruff check diabetes tests webapp`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_6895874e58fc832a846473cb2c711f48