### PR TITLE
[webapp] Allow zoom by cleaning viewport meta tags

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
     <title>Часовой пояс</title>
     <script>

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
     <title>Профиль</title>
     <script>

--- a/webapp/reminder.html
+++ b/webapp/reminder.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
     <title>Напоминание</title>
     <script>


### PR DESCRIPTION
## Summary
- drop `maximum-scale` and `user-scalable` from viewport meta tags on index, profile, and reminder pages

## Testing
- `ruff check diabetes tests`
- `pytest tests/`
- `python - <<'PY'
from playwright.sync_api import sync_playwright
import os
files=['index.html','profile.html','reminder.html']
base=os.path.abspath('webapp')
with sync_playwright() as p:
    browser=p.chromium.launch()
    for file in files:
        path=f'file://{os.path.join(base,file)}'
        for width in (320,800):
            page=browser.new_page(viewport={'width':width,'height':600})
            page.goto(path)
            inner_width=page.evaluate('() => window.innerWidth')
            print(f'{file} width={width} inner={inner_width}')
            page.close()
    browser.close()
PY`

------
https://chatgpt.com/codex/tasks/task_e_6895893e328c832ab4f92742fef796d4