### PR TITLE
[webapp] Add timezone API endpoint

### DIFF
--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import webapp.server as server
+
+
+def test_timezone_persist_and_validate(monkeypatch, tmp_path: Path) -> None:
+    tz_path = tmp_path / "tz.txt"
+    monkeypatch.setattr(server, "TIMEZONE_FILE", tz_path)
+    client = TestClient(server.app)
+
+    # valid timezone
+    resp = client.post("/api/timezone", json={"tz": "Europe/Moscow"})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    assert tz_path.read_text(encoding="utf-8") == "Europe/Moscow"
+
+    # missing tz
+    resp = client.post("/api/timezone", json={})
+    assert resp.status_code == 400
+
+    # invalid tz value
+    resp = client.post("/api/timezone", json={"tz": "Invalid/Zone"})
+    assert resp.status_code == 400
+
+    # invalid json
+    resp = client.post(
+        "/api/timezone", data="not json", headers={"Content-Type": "application/json"}
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add `/api/timezone` POST endpoint to store and validate timezone
- persist timezone value to a text file
- test timezone endpoint behavior

## Testing
- `ruff check webapp tests`
- `pytest tests -q`
- `pre-commit run --files webapp/server.py tests/test_webapp_timezone.py`


------
https://chatgpt.com/codex/tasks/task_e_6895d559fa1c832a86e606c984a72f45