### PR TITLE
[webapp] handle storage write errors

### DIFF
--- a/tests/test_webapp_server.py
+++ b/tests/test_webapp_server.py
@@ -71,3 +71,13 @@ def test_reminders_post_rejects_invalid_json() -> None:
     assert response.status_code == 400
     assert response.json() == {"detail": "invalid JSON format"}
     assert client.get("/reminders").json() == []
+
+
+def test_reminders_post_storage_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_oserror(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(server.json, "dump", raise_oserror)
+    response = client.post("/reminders", json={"text": "foo"})
+    assert response.status_code == 500
+    assert response.json() == {"detail": "storage error"}

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -29,3 +29,15 @@ def test_timezone_persist_and_validate(monkeypatch, tmp_path: Path) -> None:
         "/api/timezone", data="not json", headers={"Content-Type": "application/json"}
     )
     assert resp.status_code == 400
+
+
+def test_timezone_storage_error(monkeypatch) -> None:
+    class FailingPath:
+        def open(self, *args, **kwargs):
+            raise OSError("no space")
+
+    monkeypatch.setattr(server, "TIMEZONE_FILE", FailingPath())
+    client = TestClient(server.app)
+    resp = client.post("/api/timezone", json={"tz": "Europe/Moscow"})
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "storage error"}


### PR DESCRIPTION
## Summary
- log and return HTTP 500 when writing timezone or reminders fails
- add tests for filesystem write failures in webapp endpoints

## Testing
- `ruff check webapp tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6895e26b9ea8832abed836c92cf6b3b2