### PR TITLE
[webapp] Handle invalid reminders JSON

### DIFF
--- a/webapp/server.py
+++ b/webapp/server.py
@@ -61,8 +61,16 @@ async def _read_reminders() -> dict[int, dict]:
 
     def _read() -> dict[int, dict]:
         if REMINDERS_FILE.exists():
-            with REMINDERS_FILE.open("r", encoding="utf-8") as fh:
-                data = json.load(fh)
+            try:
+                with REMINDERS_FILE.open("r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+            except JSONDecodeError:
+                logger.warning("invalid reminders JSON; resetting storage")
+                try:
+                    REMINDERS_FILE.write_text("{}", encoding="utf-8")
+                except OSError:
+                    logger.exception("failed to reset reminders file")
+                return {}
             return {int(k): v for k, v in data.items()}
         return {}
 


### PR DESCRIPTION
## Summary
- reset invalid reminders JSON files on read errors
- log warning and return empty reminder list
- test reminder API with malformed JSON input

## Testing
- `ruff check webapp tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6895e4156ccc832ab693ae04f90f8625