### PR TITLE
Add missing os import in handlers

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -2,6 +2,7 @@ import logging
 import re
 import asyncio
 import time
+import os
 from datetime import datetime, timezone, timedelta, time as dtime
 
 logger = logging.getLogger("bot")


### PR DESCRIPTION
## Summary
- import `os` in handlers to support directory creation and avoid undefined name warnings

## Testing
- `pyflakes bot/handlers.py`
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6895e7d09ccc832a95307f791027ae7a