### PR TITLE
chore: remove unused proxy imports

### DIFF
--- a/bot/startup.py
+++ b/bot/startup.py
@@ -1,6 +1,5 @@
 import logging
-import os
-from config import OPENAI_PROXY, validate_tokens
+from config import validate_tokens
 
 
 def setup() -> logging.Logger:
@@ -16,8 +15,6 @@ def setup() -> logging.Logger:
     logger = logging.getLogger("bot")
 
     validate_tokens()
-    # os.environ["HTTP_PROXY"] = OPENAI_PROXY
-    # os.environ["HTTPS_PROXY"] = OPENAI_PROXY
 
     for name in ("httpcore", "httpx", "telegram", "telegram.ext"):
         logging.getLogger(name).setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary
- remove unused proxy imports from startup

## Testing
- `pyflakes bot/startup.py`
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6895f2810fec832ab3cb961e3b16ec65