### PR TITLE
Remove unused datetime import

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,7 +1,5 @@
 # db.py  ← полный и единственный источник моделей
 
-from datetime import datetime
-
 from sqlalchemy import (
     create_engine, Column, Integer, BigInteger, String,
     Float, Text, TIMESTAMP, ForeignKey, func


### PR DESCRIPTION
## Summary
- drop unused datetime import from db.py

## Testing
- `pyflakes db.py`
- `pytest -q` *(fails: async def functions are not natively supported; plugin needed)*

------
https://chatgpt.com/codex/tasks/task_e_6895f40ac644832a8f1e8b12e0f8976e