### PR TITLE
chore: remove unused datetime import

### DIFF
--- a/report.py
+++ b/report.py
@@ -3,7 +3,6 @@ import io
 import logging
 import os
 import re
-from datetime import datetime
 import matplotlib.pyplot as plt
 from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas


### PR DESCRIPTION
## Summary
- remove unused datetime import from report module

## Testing
- `flake8 report.py`


------
https://chatgpt.com/codex/tasks/task_e_6895f54ac0b4832a8c9005fca4a1e76c