### PR TITLE
chore: remove unused SimpleNamespace import

### DIFF
--- a/stubs/bot_stub.py
+++ b/stubs/bot_stub.py
@@ -1,5 +1,4 @@
 import re
-from types import SimpleNamespace
 
 PHOTO_SUGAR = 7
 WAITING_GPT_FLAG = "waiting_gpt_response"


### PR DESCRIPTION
## Summary
- remove unused SimpleNamespace import in bot stub

## Testing
- `pyflakes stubs/bot_stub.py`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6895f6f5d5e0832a9333cd04cd9ae84f