### PR TITLE
Remove unused pytest import from service tests

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,4 +1,3 @@
-import pytest
 from services import find_protocol_by_diagnosis
 
 


### PR DESCRIPTION
## Summary
- remove unused pytest import from tests/test_service.py

## Testing
- `flake8 tests/test_service.py`


------
https://chatgpt.com/codex/tasks/task_e_6895f84da4fc832a9cfe4529e690376d