### PR TITLE
[handlers] Handle missing callback data

### DIFF
--- a/diabetes/common_handlers.py
+++ b/diabetes/common_handlers.py
@@ -62,7 +62,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     """Handle inline button callbacks for pending entries and history actions."""
     query = update.callback_query
     await query.answer()
-    data = query.data
+    data = query.data or ""
 
     if data.startswith("rem_"):
         return


### PR DESCRIPTION
## Summary
- handle callback queries without data by defaulting to an empty string

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6895fb3aaa00832a82eb9a10a7ceea7a