### PR TITLE
[reporting] Offload DB queries to threads

### DIFF
--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import sessionmaker
 from telegram import InlineKeyboardMarkup
 
@@ -53,7 +54,11 @@ async def test_history_view_buttons(monkeypatch):
     import diabetes.common_handlers as common_handlers
     import diabetes.dose_handlers as dose_handlers
 
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
@@ -123,7 +128,11 @@ async def test_edit_flow(monkeypatch):
     import diabetes.common_handlers as common_handlers
     import diabetes.dose_handlers as dose_handlers
 
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(common_handlers, "SessionLocal", TestSession)

--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -1,0 +1,66 @@
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from diabetes import reporting_handlers
+
+
+class DummyMessage:
+    async def reply_text(self, *args, **kwargs):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_history_view_does_not_block_event_loop(monkeypatch):
+    """The database query is executed in a thread and doesn't block."""
+
+    def slow_session():
+        class FakeSession:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                pass
+
+            def query(self, *args, **kwargs):
+                class Q:
+                    def filter(self, *args, **kwargs):
+                        return self
+
+                    def order_by(self, *args, **kwargs):
+                        return self
+
+                    def limit(self, *args, **kwargs):
+                        return self
+
+                    def all(self):
+                        time.sleep(0.5)  # Blocking call executed in to_thread
+                        return []
+
+                return Q()
+
+        return FakeSession()
+
+    monkeypatch.setattr(reporting_handlers, "SessionLocal", slow_session)
+
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1),
+        message=DummyMessage(),
+    )
+    context = SimpleNamespace()
+
+    flag = False
+
+    async def marker():
+        nonlocal flag
+        await asyncio.sleep(0.1)
+        flag = True
+
+    view_task = asyncio.create_task(reporting_handlers.history_view(update, context))
+    marker_task = asyncio.create_task(marker())
+
+    await asyncio.wait_for(marker_task, timeout=0.2)
+    await view_task
+    assert flag, "Event loop was blocked during history_view"

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import pytest
 from pypdf import PdfReader
 from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("DB_PASSWORD", "test")
@@ -142,7 +143,11 @@ async def test_send_report_uses_gpt(monkeypatch):
     import diabetes.reporting_handlers as handlers
     from diabetes.db import Base, Entry, User
 
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(handlers, "SessionLocal", TestSession)


### PR DESCRIPTION
## Summary
- run history and report DB queries in `asyncio.to_thread` so the bot's event loop isn't blocked
- cover non-blocking history view with an async unit test
- adapt tests to use thread-safe SQLite connections

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6895fef0b748832a92e1d7ded849d551