### PR TITLE
[webapp] handle non-dict reminders data

### DIFF
--- a/webapp/server.py
+++ b/webapp/server.py
@@ -75,6 +75,13 @@ async def _read_reminders() -> dict[int, dict]:
                 except OSError:
                     logger.exception("failed to reset reminders file")
                 return {}
+            if not isinstance(data, dict):
+                logger.warning("reminders JSON is not a dict; resetting storage")
+                try:
+                    REMINDERS_FILE.write_text("{}", encoding="utf-8")
+                except OSError:
+                    logger.exception("failed to reset reminders file")
+                return {}
             return {int(k): v for k, v in data.items()}
         return {}
 


### PR DESCRIPTION
## Summary
- validate reminders JSON structure before iterating
- reset storage if reminders data isn't a dictionary

## Testing
- `ruff check webapp diabetes tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689605cc0b94832aa5a8c62dee7ff3ca