### PR TITLE
[webapp] add Telegram WebApp type declarations

### DIFF
--- a/webapp/ui/src/global.d.ts
+++ b/webapp/ui/src/global.d.ts
@@ -1,0 +1,14 @@
+export {};
+
+declare global {
+  interface TelegramWebApp {
+    sendData(data: string): void;
+  }
+
+  interface Window {
+    Telegram?: {
+      WebApp?: TelegramWebApp;
+    };
+  }
+}
+

--- a/webapp/ui/src/hooks/useTimezone.ts
+++ b/webapp/ui/src/hooks/useTimezone.ts
@@ -16,9 +16,7 @@ export function useTimezone() {
     const value = forceDetect ? detect() : tz;
     if (!value) return;
     try {
-      // @ts-ignore
       if (window?.Telegram?.WebApp?.sendData) {
-        // @ts-ignore
         window.Telegram.WebApp.sendData(value);
       }
       await fetch("/api/timezone", {


### PR DESCRIPTION
## Summary
- declare TelegramWebApp global type
- use Telegram WebApp type in timezone hook

## Testing
- `npm --prefix webapp/ui run build` *(fails: Rollup failed to resolve import "/ui/assets/index-B7rb8RQX.js" from "/workspace/diabetes-assistant/webapp/ui/index.html")*
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68960c960300832a9e43e71f8e7db3a6