### PR TITLE
[webapp] Handle timezone fetch errors

### DIFF
--- a/webapp/ui/src/hooks/useTimezone.ts
+++ b/webapp/ui/src/hooks/useTimezone.ts
@@ -19,12 +19,29 @@ export function useTimezone() {
       if (window?.Telegram?.WebApp?.sendData) {
         window.Telegram.WebApp.sendData(value);
       }
-      await fetch("/api/timezone", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ tz: value }),
-      });
-    } catch (e) { console.warn("submit timezone failed", e); }
+      const send = async () =>
+        fetch("/api/timezone", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ tz: value }),
+        });
+      let response = await send();
+      if (!response.ok) {
+        console.error("submit timezone failed", response.statusText);
+        response = await send();
+        if (!response.ok) {
+          console.error("submit timezone retry failed", response.statusText);
+          window.Telegram?.WebApp?.showAlert?.(
+            "Не удалось сохранить часовой пояс. Попробуйте позже."
+          );
+        }
+      }
+    } catch (e) {
+      console.warn("submit timezone failed", e);
+      window.Telegram?.WebApp?.showAlert?.(
+        "Не удалось сохранить часовой пояс. Попробуйте позже."
+      );
+    }
   }, [tz, detect]);
 
   return { tz, setTz, detect, submit };


### PR DESCRIPTION
## Summary
- retry timezone submission and alert user if requests fail

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68960e58c530832aa3d64ccc0dedec4c