### PR TITLE
[webapp] Handle non-numeric reminder keys

### DIFF
--- a/tests/test_webapp_server.py
+++ b/tests/test_webapp_server.py
@@ -93,3 +93,14 @@ def test_reminders_get_handles_invalid_json(caplog: pytest.LogCaptureFixture) ->
 
     assert server.REMINDERS_FILE.read_text(encoding="utf-8") == "{}"
     assert "invalid reminders JSON" in caplog.text
+
+
+def test_reminders_get_handles_non_numeric_keys(caplog: pytest.LogCaptureFixture) -> None:
+    """Non-numeric reminder keys should log a warning and reset the file."""
+    server.REMINDERS_FILE.write_text('{"foo": {"text": "bar"}}', encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        assert client.get("/reminders").json() == []
+
+    assert server.REMINDERS_FILE.read_text(encoding="utf-8") == "{}"
+    assert "non-numeric reminder key" in caplog.text

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -83,7 +83,15 @@ async def _read_reminders() -> dict[int, dict]:
                 except OSError:
                     logger.exception("failed to reset reminders file")
                 return {}
-            return {int(k): v for k, v in data.items()}
+            try:
+                return {int(k): v for k, v in data.items()}
+            except ValueError:
+                logger.warning("non-numeric reminder key; resetting storage")
+                try:
+                    REMINDERS_FILE.write_text("{}", encoding="utf-8")
+                except OSError:
+                    logger.exception("failed to reset reminders file")
+                return {}
         return {}
 
     return await asyncio.to_thread(_read)


### PR DESCRIPTION
## Summary
- reset reminders storage when encountering non-numeric keys
- add regression test for non-numeric reminder IDs

## Testing
- `ruff check webapp tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689611d00c38832a8b40479da112b817