### PR TITLE
[gpt_parser] reuse default thread pool

### DIFF
--- a/diabetes/gpt_command_parser.py
+++ b/diabetes/gpt_command_parser.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import json
 import re
-from concurrent.futures import ThreadPoolExecutor
 
 from openai import OpenAIError
 
@@ -72,22 +71,24 @@ def _extract_first_json(text: str) -> dict | None:
 
 
 async def parse_command(text: str, timeout: float = 10) -> dict | None:
-    executor = ThreadPoolExecutor(max_workers=1)
-    future = executor.submit(
-        _get_client().chat.completions.create,
-        model="gpt-4o-mini",
-        messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": text},
-        ],
-        temperature=0,
-        max_tokens=256,
-        timeout=timeout,
-    )
     try:
-        response = await asyncio.wait_for(asyncio.wrap_future(future), timeout)
+        # ``asyncio.to_thread`` reuses the loop's default thread pool, avoiding
+        # the overhead of creating a new ``ThreadPoolExecutor`` on each call.
+        response = await asyncio.wait_for(
+            asyncio.to_thread(
+                _get_client().chat.completions.create,
+                model="gpt-4o-mini",
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": text},
+                ],
+                temperature=0,
+                max_tokens=256,
+                timeout=timeout,
+            ),
+            timeout,
+        )
     except asyncio.TimeoutError:
-        future.cancel()
         logging.error("Command parsing timed out")
         return None
     except OpenAIError:
@@ -96,8 +97,6 @@ async def parse_command(text: str, timeout: float = 10) -> dict | None:
     except Exception:
         logging.exception("Unexpected error during command parsing")
         return None
-    finally:
-        executor.shutdown(wait=False, cancel_futures=True)
 
     choices = getattr(response, "choices", None)
     if not choices:


### PR DESCRIPTION
## Summary
- run synchronous OpenAI calls in a shared thread pool via `asyncio.to_thread`
- handle timeouts/errors without per-call `ThreadPoolExecutor`

## Testing
- `ruff check diabetes tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689618cb5e88832a9fde024a0faa5563