### PR TITLE
[webapp] ensure timezone auto submission runs once

### DIFF
--- a/webapp/ui/src/components/TimezoneAuto.tsx
+++ b/webapp/ui/src/components/TimezoneAuto.tsx
@@ -4,6 +4,9 @@ import { useTimezone } from "../hooks/useTimezone";
 
 export default function TimezoneAuto() {
   const { submit } = useTimezone();
-  useEffect(() => { submit(true); }, [submit]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    submit(true);
+  }, []);
   return null;
 }


### PR DESCRIPTION
## Summary
- call timezone submit effect only once on mount

## Testing
- `ruff check diabetes tests`
- `pytest tests/`
- `npm run build` *(fails: Rollup failed to resolve import /ui/assets/index-B7rb8RQX.js)*

------
https://chatgpt.com/codex/tasks/task_e_6896187a2934832a83e195c55f457f51