### PR TITLE
[gpt_parser] Ensure json, re, asyncio and logging imports

### DIFF
--- a/diabetes/gpt_command_parser.py
+++ b/diabetes/gpt_command_parser.py
@@ -1,6 +1,6 @@
 import asyncio
-import logging
 import json
+import logging
 import re
 
 from openai import OpenAIError


### PR DESCRIPTION
## Summary
- align `gpt_command_parser` imports with the stdlib modules used: `asyncio`, `json`, `logging`, and `re`

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689638e231f0832ab01e04b8874fea39