### PR TITLE
Return 404 for unknown diagnosis

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from services import find_protocol_by_diagnosis
 
@@ -13,5 +13,7 @@ class DiagnoseResponse(BaseModel):
 @app.post("/v1/ai/diagnose", response_model=DiagnoseResponse)
 async def ai_diagnose(req: DiagnoseRequest) -> DiagnoseResponse:
     protocol = find_protocol_by_diagnosis(req.diagnosis)
+    if protocol is None:
+        raise HTTPException(status_code=404, detail="Protocol not found")
     return DiagnoseResponse(protocol=protocol)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import pytest
+from fastapi import HTTPException
 
 from api import ai_diagnose, DiagnoseRequest
 
@@ -8,7 +9,9 @@ async def test_ai_diagnose_with_protocol():
     assert result.protocol == "standard protocol"
 
 @pytest.mark.asyncio
-async def test_ai_diagnose_without_protocol():
-    result = await ai_diagnose(DiagnoseRequest(diagnosis="unknown"))
-    assert result.protocol is None
+async def test_ai_diagnose_unknown_diagnosis_returns_404():
+    with pytest.raises(HTTPException) as exc_info:
+        await ai_diagnose(DiagnoseRequest(diagnosis="unknown"))
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Protocol not found"
 


### PR DESCRIPTION
## Summary
- raise HTTP 404 when no protocol is found for a diagnosis
- test API endpoint returns 404 for unknown diagnosis

## Testing
- `pip install -r requirements-test.txt`
- `pytest tests/test_api.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964fe2b994832a9741162e17edd92f