### PR TITLE
[handlers] End profile conversation on save failure

### DIFF
--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -150,7 +150,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         prof.high_threshold = high
         if not commit_session(session):
             await update.message.reply_text("⚠️ Не удалось сохранить профиль.")
-            return
+            return ConversationHandler.END
 
     await update.message.reply_text(
         f"✅ Профиль обновлён:\n"

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
+from telegram.ext import ConversationHandler
 import diabetes.profile_handlers as profile_handlers
 import diabetes.common_handlers as common_handlers
 import diabetes.reminder_handlers as reminder_handlers
@@ -60,11 +61,12 @@ async def test_profile_command_commit_failure(monkeypatch, caplog):
     context = SimpleNamespace(args=["10", "2", "6", "4", "9"], user_data={})
 
     with caplog.at_level(logging.ERROR):
-        await profile_handlers.profile_command(update, context)
+        result = await profile_handlers.profile_command(update, context)
 
     assert session.rollback.called
     assert "DB commit failed" in caplog.text
     assert message.texts == ["⚠️ Не удалось сохранить профиль."]
+    assert result == ConversationHandler.END
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ensure profile save errors end the `/profile` conversation
- extend commit-failure test to check the conversation terminates

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68966bac350c832abfd3d231ed0a99e0