### PR TITLE
feat: add reminder scheduler

### DIFF
--- a/db.py
+++ b/db.py
@@ -54,6 +54,16 @@ class Entry(Base):
     gpt_summary  = Column(Text)
 
 
+class Reminder(Base):
+    __tablename__ = "reminders"
+
+    id          = Column(Integer, primary_key=True, index=True)
+    telegram_id = Column(BigInteger, ForeignKey("users.telegram_id"))
+    time        = Column(TIMESTAMP, nullable=False)
+    message     = Column(Text, nullable=False)
+    created_at  = Column(TIMESTAMP, server_default=func.now())
+
+
 # ────────────────────── инициализация ────────────────────────
 def init_db() -> None:
     """Создать таблицы, если их ещё нет (для локального запуска)."""

--- a/db_access.py
+++ b/db_access.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 from typing import List
-from db import SessionLocal, Profile, Entry
+from db import SessionLocal, Profile, Entry, Reminder
 
 
 def save_profile(user_id: int, icr: float, cf: float, target: float) -> None:
@@ -42,3 +42,34 @@ def get_entries_since(user_id: int, date_from: datetime) -> List[Entry]:
             .order_by(Entry.event_time)
             .all()
         )
+
+
+def add_reminder(user_id: int, remind_at: datetime, message: str) -> int:
+    with SessionLocal() as session:
+        reminder = Reminder(
+            telegram_id=user_id,
+            time=remind_at,
+            message=message,
+        )
+        session.add(reminder)
+        session.commit()
+        session.refresh(reminder)
+        return reminder.id
+
+
+def get_user_reminders(user_id: int) -> List[Reminder]:
+    with SessionLocal() as session:
+        return (
+            session.query(Reminder)
+            .filter(Reminder.telegram_id == user_id)
+            .order_by(Reminder.time)
+            .all()
+        )
+
+
+def delete_reminder(reminder_id: int) -> None:
+    with SessionLocal() as session:
+        reminder = session.get(Reminder, reminder_id)
+        if reminder:
+            session.delete(reminder)
+            session.commit()

--- a/gpt_command_parser.py
+++ b/gpt_command_parser.py
@@ -25,6 +25,7 @@ SYSTEM_PROMPT = (
     '"update_profile" | "set_reminder" | "get_stats" | "get_day_summary",\n'
     '  "entry_date": "YYYY-MM-DDTHH:MM:SS",      // ⇦ указывай ТОЛЬКО если есть полная дата\n'
     '  "time": "HH:MM",                          // ⇦ если в сообщении было лишь время\n'
+    '  "message": "...",                         // ⇦ текст напоминания для set_reminder\n'
     '  "fields": { ... }                         // xe, carbs_g, dose, sugar_before и пр.\n'
     "}\n\n"
 
@@ -43,6 +44,8 @@ SYSTEM_PROMPT = (
     "Пример 2 (полная дата):\n"
     "  {\"action\":\"add_entry\",\"entry_date\":\"2025-05-04T20:00:00\","
     "\"fields\":{\"carbs_g\":60,\"dose\":6}}\n"
+    "Пример 3 (напоминание):\n"
+    "  {\"action\":\"set_reminder\",\"time\":\"09:00\",\"message\":\"проверить сахар\"}\n"
 )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ httpx==0.24.1
 idna==3.10
 jiter==0.9.0
 openai==1.74.0
+APScheduler==3.10.4
 psycopg2-binary==2.9.6
 pydantic==2.11.4
 pydantic_core==2.33.2

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1,0 +1,64 @@
+import asyncio
+from datetime import datetime, timedelta
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import db
+import db_access
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    TestingSession = sessionmaker(bind=engine)
+    db.Base.metadata.create_all(engine)
+
+    monkeypatch.setattr(db, "engine", engine)
+    monkeypatch.setattr(db, "SessionLocal", TestingSession)
+    monkeypatch.setattr(db_access, "SessionLocal", TestingSession)
+    # create user for FK
+    with TestingSession() as s:
+        from db import User
+        s.add(User(telegram_id=1, thread_id="t"))
+        s.commit()
+    yield
+
+
+class DummyBot:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, chat_id, text):
+        self.messages.append((chat_id, text))
+
+
+@pytest.mark.asyncio
+async def test_reminder_triggers():
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+    from bot.handlers import reminder_job
+
+    bot = DummyBot()
+    remind_time = datetime.now() + timedelta(seconds=0.3)
+    reminder_id = db_access.add_reminder(1, remind_time, "test")
+    sched = AsyncIOScheduler()
+    sched.start()
+    sched.add_job(
+        reminder_job,
+        "date",
+        run_date=remind_time,
+        args=(bot, 1, "test", reminder_id),
+    )
+    await asyncio.sleep(0.5)
+    assert bot.messages == [(1, "test")]
+    assert db_access.get_user_reminders(1) == []
+    sched.remove_all_jobs()
+
+
+def test_add_and_delete_reminder():
+    now = datetime.now() + timedelta(minutes=5)
+    rid = db_access.add_reminder(1, now, "hi")
+    reminders = db_access.get_user_reminders(1)
+    assert len(reminders) == 1 and reminders[0].id == rid
+    db_access.delete_reminder(rid)
+    assert db_access.get_user_reminders(1) == []


### PR DESCRIPTION
## Summary
- add Reminder model and DB helpers
- schedule set_reminder commands with APScheduler
- test reminder creation and trigger

## Testing
- `pip install -r requirements-test.txt`
- `pip install APScheduler==3.10.4`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68965d8738ac832a98d3cf21f6f45af5