### PR TITLE
[utils] Handle single-digit hours in time parser

### DIFF
--- a/diabetes/utils.py
+++ b/diabetes/utils.py
@@ -30,6 +30,8 @@ def parse_time_interval(value: str) -> time | timedelta:
     """Convert strings like 'HH:MM', 'H:MM', 'Nh' or 'Nd' to time or timedelta."""
 
     value = value.strip()
+    if re.fullmatch(r"\d:\d{2}", value):
+        value = f"0{value}"
     try:
         return datetime.strptime(value, "%H:%M").time()
     except ValueError:

--- a/tests/test_parse_time_interval.py
+++ b/tests/test_parse_time_interval.py
@@ -8,6 +8,8 @@ from diabetes.utils import INVALID_TIME_MSG, parse_time_interval
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
+        ("09:30", time(9, 30)),
+        ("9:30", time(9, 30)),
         ("22:30", time(22, 30)),
         ("6:00", time(6, 0)),
     ],


### PR DESCRIPTION
## Summary
- normalize single-digit hour times before `datetime.strptime`
- test both `09:30` and `9:30` parsing

## Testing
- `ruff check diabetes tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68966d97dacc832aa7e774622a9bb03d