### PR TITLE
[bot] Validate MAINTAINER_CHAT_ID env value

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,15 @@ import os
 import sys
 
 logger = logging.getLogger(__name__)
-MAINTAINER_CHAT_ID = os.getenv("MAINTAINER_CHAT_ID")
+
+MAINTAINER_CHAT_ID_ENV = os.getenv("MAINTAINER_CHAT_ID")
+try:
+    MAINTAINER_CHAT_ID = (
+        int(MAINTAINER_CHAT_ID_ENV) if MAINTAINER_CHAT_ID_ENV is not None else None
+    )
+except (TypeError, ValueError):
+    logger.warning("Invalid MAINTAINER_CHAT_ID: %s", MAINTAINER_CHAT_ID_ENV)
+    MAINTAINER_CHAT_ID = None
 
 
 async def error_handler(update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- Ensure MAINTAINER_CHAT_ID env var is cast to int and gracefully handled if invalid

## Testing
- `ruff check bot.py diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689678c1a4cc832a95568cc1d43b9563