### PR TITLE
[utils] Normalize single-digit time strings

### DIFF
--- a/diabetes/utils.py
+++ b/diabetes/utils.py
@@ -30,7 +30,8 @@ def parse_time_interval(value: str) -> time | timedelta:
     """Convert strings like 'HH:MM', 'H:MM', 'Nh' or 'Nd' to time or timedelta."""
 
     value = value.strip()
-    if re.fullmatch(r"\d:\d{2}", value):
+    # Normalize times like `9:30` -> `09:30` before parsing
+    if re.match(r"^\d:\d{2}$", value):
         value = f"0{value}"
     try:
         return datetime.strptime(value, "%H:%M").time()

--- a/tests/test_parse_time_interval.py
+++ b/tests/test_parse_time_interval.py
@@ -5,11 +5,17 @@ import pytest
 from diabetes.utils import INVALID_TIME_MSG, parse_time_interval
 
 
+def test_parse_time_zero_padded():
+    assert parse_time_interval("09:30") == time(9, 30)
+
+
+def test_parse_time_single_digit_hour():
+    assert parse_time_interval("9:30") == time(9, 30)
+
+
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("09:30", time(9, 30)),
-        ("9:30", time(9, 30)),
         ("22:30", time(22, 30)),
         ("6:00", time(6, 0)),
     ],


### PR DESCRIPTION
## Summary
- normalize unpadded `H:MM` times by prepending a leading zero before parsing
- add dedicated tests for zero-padded and single-digit hour inputs

## Testing
- `ruff check diabetes tests`
- `pytest tests/test_parse_time_interval.py::test_parse_time_zero_padded tests/test_parse_time_interval.py::test_parse_time_single_digit_hour`
- `pytest tests/test_parse_time_interval.py`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6896cb8e0c9c832abb650c001bc3d139