### PR TITLE
[bot] Cast MAINTAINER_CHAT_ID to int with fallback

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,13 +15,13 @@ import sys
 
 logger = logging.getLogger(__name__)
 
-MAINTAINER_CHAT_ID_ENV = os.getenv("MAINTAINER_CHAT_ID")
+MAINTAINER_CHAT_ID = os.getenv("MAINTAINER_CHAT_ID")
 try:
     MAINTAINER_CHAT_ID = (
-        int(MAINTAINER_CHAT_ID_ENV) if MAINTAINER_CHAT_ID_ENV is not None else None
+        int(MAINTAINER_CHAT_ID) if MAINTAINER_CHAT_ID is not None else None
     )
 except (TypeError, ValueError):
-    logger.warning("Invalid MAINTAINER_CHAT_ID: %s", MAINTAINER_CHAT_ID_ENV)
+    logger.warning("Invalid MAINTAINER_CHAT_ID: %s", MAINTAINER_CHAT_ID)
     MAINTAINER_CHAT_ID = None
 
 


### PR DESCRIPTION
## Summary
- Convert `MAINTAINER_CHAT_ID` from environment to `int` with error handling

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6896cd9237f4832a831dad5743491534