### PR TITLE
[webapp] Add base path for BrowserRouter

### DIFF
--- a/webapp/spa/src/App.tsx
+++ b/webapp/spa/src/App.tsx
@@ -45,7 +45,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename="/ui">
         <AppContent />
       </BrowserRouter>
     </TooltipProvider>


### PR DESCRIPTION
## Summary
- configure BrowserRouter to serve the SPA under `/ui`

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "@/components/ui/toaster")*
- `ruff check diabetes tests`
- `pytest tests` *(fails: 4 failed, 201 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68978a761364832a987a233024ab48d5