### PR TITLE
[handlers] Update reminder webapp URLs

### DIFF
--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -386,7 +386,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         elif action == "add":
             if WEBAPP_URL:
                 button = InlineKeyboardButton(
-                    "📝 Новое", web_app=WebAppInfo(f"{WEBAPP_URL}/reminder")
+                    "📝 Новое", web_app=WebAppInfo(f"{WEBAPP_URL}/reminders")
                 )
                 keyboard = InlineKeyboardMarkup([[button]])
                 await query.message.reply_text(

--- a/diabetes/reminder_handlers.py
+++ b/diabetes/reminder_handlers.py
@@ -121,7 +121,7 @@ def _render_reminders(user_id: int) -> tuple[str, InlineKeyboardMarkup]:
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
-                web_app=WebAppInfo(f"{WEBAPP_URL}/reminder"),
+                web_app=WebAppInfo(f"{WEBAPP_URL}/reminders"),
             )
         ]
     if not rems:
@@ -147,7 +147,7 @@ def _render_reminders(user_id: int) -> tuple[str, InlineKeyboardMarkup]:
             row.append(
                 InlineKeyboardButton(
                     "✏️",
-                    web_app=WebAppInfo(f"{WEBAPP_URL}/reminder?id={r.id}"),
+                    web_app=WebAppInfo(f"{WEBAPP_URL}/reminders?id={r.id}"),
                 )
             )
         row.extend(

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -162,7 +162,7 @@ def test_render_reminders_formatting(monkeypatch):
     assert "📸 Триггер-фото" in text
     assert "2. <s>🔕title2</s>" in text
     btn = markup.inline_keyboard[-1][0]
-    assert btn.web_app and btn.web_app.url.endswith("/reminder")
+    assert btn.web_app and btn.web_app.url.endswith("/reminders")
 
 
 def test_render_reminders_no_webapp(monkeypatch):


### PR DESCRIPTION
## Summary
- point reminder add/edit buttons to `/reminders` webapp path
- update profile menu button to open `/reminders`
- fix reminder rendering test accordingly

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68979945b728832a99ab33c7f967071c