### PR TITLE
webapp: remove legacy UI reminder redirects

### DIFF
--- a/webapp/server.py
+++ b/webapp/server.py
@@ -164,14 +164,6 @@ async def reminders_post(request: Request) -> dict:
 
 # ---------- Совместимость для старых относительных путей из UI ----------
 # ВАЖНО: эти маршруты должны быть ДО mount('/ui'), иначе их перехватит StaticFiles.
-@app.get("/ui/reminder")
-async def _compat_ui_reminder(id: int | None = None) -> RedirectResponse:
-    q = f"?id={id}" if id is not None else ""
-    return RedirectResponse(url=f"/reminders{q}", status_code=307)
-
-@app.get("/ui/reminders")
-async def _compat_ui_reminders() -> RedirectResponse:
-    return RedirectResponse(url="/reminders", status_code=307)
 
 @app.post("/ui/api/timezone")
 async def _compat_ui_timezone(request: Request) -> dict:


### PR DESCRIPTION
## Summary
- remove compatibility routes for `/ui/reminder` and `/ui/reminders`
- rely on SPA static files for reminder pages

## Testing
- `ruff check webapp tests/test_webapp_server.py tests/test_webapp_timezone.py`
- `pytest tests/test_webapp_server.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a57f9d60832abb7f2aad13f1f785