### PR TITLE
[webapp] Force light theme for webapp

### DIFF
--- a/webapp/style.css
+++ b/webapp/style.css
@@ -1,13 +1,14 @@
+/* Force light color scheme regardless of Telegram theme */
 :root {
-    color-scheme: light dark;
+    color-scheme: light;
 }
 
 body {
     font-family: Arial, sans-serif;
     font-size: 18px;
     margin: 20px;
-    background-color: var(--tg-theme-bg-color, #ffffff);
-    color: var(--tg-theme-text-color, #000000);
+    background-color: #ffffff;
+    color: #000000;
 }
 
 form {
@@ -29,20 +30,20 @@ select,
 button {
     padding: 8px;
     font-size: 1rem;
-    color: inherit;
-    background-color: var(--tg-theme-bg-color, #ffffff);
-    border: 1px solid var(--tg-theme-text-color, #000000);
+    color: #000000;
+    background-color: #ffffff;
+    border: 1px solid #000000;
 }
 
 button {
     cursor: pointer;
-    background-color: var(--tg-theme-button-color, #2481cc);
-    color: var(--tg-theme-button-text-color, var(--tg-theme-bg-color, #ffffff));
+    background-color: #2481cc;
+    color: #ffffff;
     border: none;
 }
 .hint {
     display: block;
     margin-top: 4px;
     font-size: 0.9rem;
-    color: var(--tg-theme-hint-color, gray);
+    color: #888888;
 }

--- a/webapp/telegram-init.js
+++ b/webapp/telegram-init.js
@@ -1,4 +1,20 @@
 if (window.Telegram && Telegram.WebApp) {
-    Telegram.WebApp.ready();
-    Telegram.WebApp.expand();
+    const webApp = Telegram.WebApp;
+    webApp.ready();
+    webApp.expand();
+
+    const applyLightTheme = () => {
+        webApp.setBackgroundColor('#ffffff');
+        webApp.setHeaderColor('#ffffff');
+    };
+
+    if (webApp.colorScheme !== 'light') {
+        applyLightTheme();
+    }
+
+    webApp.onEvent('themeChanged', () => {
+        if (webApp.colorScheme !== 'light') {
+            applyLightTheme();
+        }
+    });
 }


### PR DESCRIPTION
## Summary
- Replace Telegram theme variables with fixed light colors and force `color-scheme: light`
- Read `Telegram.WebApp.colorScheme` and override header/background to stay light, even on theme change

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6897b1e9f8bc832a8ce32e3efdd7e4bc