### PR TITLE
[tests] Use content parameter for invalid JSON

### DIFF
--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -26,7 +26,7 @@ def test_timezone_persist_and_validate(monkeypatch, tmp_path: Path) -> None:
 
     # invalid json
     resp = client.post(
-        "/api/timezone", data="not json", headers={"Content-Type": "application/json"}
+        "/api/timezone", content=b"not json", headers={"Content-Type": "application/json"}
     )
     assert resp.status_code == 400
 


### PR DESCRIPTION
## Summary
- fix invalid JSON test to send raw content rather than form data

## Testing
- `ruff check tests/test_webapp_timezone.py`
- `pytest tests/test_webapp_timezone.py`


------
https://chatgpt.com/codex/tasks/task_e_6897b2dfe3c4832aa2a3c54bcfc8d46d