### PR TITLE
[functions] Validate smart_input values

### DIFF
--- a/diabetes/functions.py
+++ b/diabetes/functions.py
@@ -260,7 +260,7 @@ def smart_input(message: str) -> dict[str, float | None]:
 
     # --- Sugar ---
     m = re.search(
-        r"\b(?:sugar|сахар)\s*[:=]?\s*(\d+[.,]?\d*)(?:\s*(ммоль/?л|mmol/?l))?",
+        r"\b(?:sugar|сахар)\s*[:=]?\s*(\d+[.,]?\d*)(?=(?:\s*(?:ммоль/?л|mmol/?l))?\b)",
         text,
     )
     if m:
@@ -271,7 +271,7 @@ def smart_input(message: str) -> dict[str, float | None]:
             result["sugar"] = _safe_float(m.group(1))
 
     # --- XE ---
-    m = re.search(r"\b(?:xe|хе)\s*[:=]?\s*(\d+[.,]?\d*)", text)
+    m = re.search(r"\b(?:xe|хе)\s*[:=]?\s*(\d+[.,]?\d*)\b", text)
     if m:
         result["xe"] = _safe_float(m.group(1))
     else:
@@ -280,7 +280,7 @@ def smart_input(message: str) -> dict[str, float | None]:
             result["xe"] = _safe_float(m.group(1))
 
     # --- Dose ---
-    m = re.search(r"\b(?:dose|доза|болюс)\s*[:=]?\s*(\d+[.,]?\d*)", text)
+    m = re.search(r"\b(?:dose|доза|болюс)\s*[:=]?\s*(\d+[.,]?\d*)\b", text)
     if m:
         result["dose"] = _safe_float(m.group(1))
     else:

--- a/tests/test_smart_input.py
+++ b/tests/test_smart_input.py
@@ -19,3 +19,12 @@ def test_smart_input_valid_cases(message, expected):
 def test_smart_input_invalid_dose():
     with pytest.raises(ValueError):
         smart_input("доза=abc")
+
+
+@pytest.mark.parametrize(
+    "message",
+    ["sugar=7abc", "xe=3foo", "dose=4bar"],
+)
+def test_smart_input_rejects_garbage(message: str) -> None:
+    with pytest.raises(ValueError):
+        smart_input(message)


### PR DESCRIPTION
## Summary
- enforce trailing boundaries for sugar, XE and dose in `smart_input`
- reject values with trailing garbage
- test parsing rejects `sugar=7abc`, `xe=3foo`, `dose=4bar`

## Testing
- `ruff check diabetes tests`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68980715e850832a98a1d47f42a4783e