### PR TITLE
[onboarding] Gracefully handle missing demo photo

### DIFF
--- a/diabetes/onboarding_handlers.py
+++ b/diabetes/onboarding_handlers.py
@@ -220,10 +220,17 @@ async def onboarding_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE
     keyboard = InlineKeyboardMarkup(
         [[InlineKeyboardButton("Далее", callback_data="onb_next")]]
     )
-    with open("assets/demo.jpg", "rb") as photo:
-        await update.message.reply_photo(
-            photo=photo,
-            caption="2/3. Вот пример распознавания еды.",
+    try:
+        with open("assets/demo.jpg", "rb") as photo:
+            await update.message.reply_photo(
+                photo=photo,
+                caption="2/3. Вот пример распознавания еды.",
+                reply_markup=keyboard,
+            )
+    except OSError:
+        logger.exception("Failed to open demo photo")
+        await update.message.reply_text(
+            "2/3. Демо-фото недоступно.",
             reply_markup=keyboard,
         )
     return ONB_DEMO

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -1,0 +1,76 @@
+import os
+from types import SimpleNamespace
+
+import logging
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from diabetes.db import Base
+
+
+class DummyMessage:
+    def __init__(self):
+        self.texts = []
+        self.photos = []
+        self.markups = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+        self.markups.append(kwargs.get("reply_markup"))
+
+    async def reply_photo(self, photo, caption=None, **kwargs):
+        self.photos.append((photo, caption))
+        self.markups.append(kwargs.get("reply_markup"))
+
+
+@pytest.mark.asyncio
+async def test_onboarding_demo_photo_missing(monkeypatch, caplog):
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+
+    import diabetes.common_handlers  # noqa: F401
+    import diabetes.onboarding_handlers as onboarding
+    import diabetes.gpt_client as gpt_client
+
+    monkeypatch.setattr(gpt_client, "create_thread", lambda: "tid")
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
+    monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
+
+    message = DummyMessage()
+    update = SimpleNamespace(
+        message=message, effective_user=SimpleNamespace(id=1, first_name="Ann")
+    )
+    context = SimpleNamespace(user_data={}, bot_data={})
+
+    await onboarding.start_command(update, context)
+    update.message.text = "10"
+    await onboarding.onboarding_icr(update, context)
+    update.message.text = "3"
+    await onboarding.onboarding_cf(update, context)
+    update.message.text = "6"
+    await onboarding.onboarding_target(update, context)
+
+    import builtins
+
+    orig_open = builtins.open
+
+    def fake_open(path, *args, **kwargs):
+        if path == "assets/demo.jpg":
+            raise OSError("missing")
+        return orig_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    update.message.text = "Europe/Moscow"
+    with caplog.at_level(logging.ERROR):
+        state = await onboarding.onboarding_timezone(update, context)
+
+    assert state == onboarding.ONB_DEMO
+    assert not message.photos
+    assert "Демо-фото недоступно" in message.texts[-1]
+    assert any("Failed to open demo photo" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- handle missing demo photo during onboarding by logging and sending text fallback
- add regression test for missing demo image

## Testing
- `ruff check diabetes tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68980da0baa0832a9dcea469db646686