### PR TITLE
Add Telegram WebApp with custom theme

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Diabetes Assistant WebApp</title>
+  <style>
+    :root {
+      --tg-theme-bg-color: #f5f5f5;
+      --tg-theme-text-color: #222222;
+      --tg-theme-button-color: #007bff;
+      --tg-theme-button-text-color: #ffffff;
+      --tg-theme-link-color: #007bff;
+    }
+
+    body {
+      background: var(--tg-theme-bg-color);
+      color: var(--tg-theme-text-color);
+      font-family: sans-serif;
+      margin: 0;
+      padding: 1rem;
+    }
+
+    a {
+      color: var(--tg-theme-link-color);
+    }
+
+    button {
+      background: var(--tg-theme-button-color);
+      color: var(--tg-theme-button-text-color);
+      border: none;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <h1>Diabetes Assistant WebApp</h1>
+  <p>Welcome to the web app!</p>
+  <button id="action">Click me</button>
+
+  <script>
+    const tg = window.Telegram ? window.Telegram.WebApp : undefined;
+    if (tg) {
+      tg.ready();
+      tg.colorScheme = 'light';
+      const customTheme = {
+        bg_color: '#f5f5f5',
+        text_color: '#222222',
+        button_color: '#007bff',
+        button_text_color: '#ffffff',
+        link_color: '#007bff'
+      };
+      Object.entries(customTheme).forEach(([key, value]) => {
+        document.documentElement.style.setProperty(`--tg-theme-${key.replace(/_/g, '-')}`, value);
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add basic WebApp index page
- override Telegram theme variables with custom colors and force light color scheme

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689814cbde80832a8aa135157495c488