### PR TITLE
Customize Telegram WebApp theme

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -3,13 +3,25 @@
 <head>
   <meta charset="UTF-8" />
   <title>Diabetes Assistant WebApp</title>
+  <script>
+    (function ensureNoTheme() {
+      if (!location.hash.includes('tgNoTheme=1')) {
+        if (location.hash) {
+          location.hash += '&tgNoTheme=1';
+        } else {
+          location.hash = 'tgNoTheme=1';
+        }
+      }
+    })();
+  </script>
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <style>
     :root {
-      --tg-theme-bg-color: #f5f5f5;
-      --tg-theme-text-color: #222222;
-      --tg-theme-button-color: #007bff;
-      --tg-theme-button-text-color: #ffffff;
-      --tg-theme-link-color: #007bff;
+      --tg-theme-bg-color: #f5f5f5 !important;
+      --tg-theme-text-color: #222222 !important;
+      --tg-theme-button-color: #007bff !important;
+      --tg-theme-button-text-color: #ffffff !important;
+      --tg-theme-link-color: #007bff !important;
     }
 
     body {
@@ -40,12 +52,6 @@
   <button id="action">Click me</button>
 
   <script>
-    (function ensureNoTheme() {
-      if (!location.hash.includes('tgNoTheme=1')) {
-        location.hash = 'tgNoTheme=1';
-      }
-    })();
-
     const tg = window.Telegram ? window.Telegram.WebApp : undefined;
     if (tg) {
       tg.ready();
@@ -59,7 +65,7 @@
           link_color: '#007bff'
         };
         Object.entries(customTheme).forEach(([key, value]) => {
-          document.documentElement.style.setProperty(`--tg-theme-${key.replace(/_/g, '-')}`, value);
+          document.documentElement.style.setProperty(`--tg-theme-${key.replace(/_/g, '-')}`, value, 'important');
         });
         tg.setBackgroundColor(customTheme.bg_color);
         tg.setHeaderColor(customTheme.bg_color);


### PR DESCRIPTION
## Summary
- Ensure Telegram's default theme is disabled early and load WebApp script
- Override CSS variables and set background, header, and bottom bar colors with Telegram API
- Reapply theme on `themeChanged` events

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6898205f77e8832a8b853a608bcdc933