### PR TITLE
[handlers] Handle commit session failures

### DIFF
--- a/diabetes/onboarding_handlers.py
+++ b/diabetes/onboarding_handlers.py
@@ -215,7 +215,12 @@ async def onboarding_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE
         user = session.get(User, user_id)
         if user:
             user.timezone = tz_name
-            commit_session(session)
+            if not commit_session(session):
+                await update.message.reply_text(
+                    "⚠️ Не удалось сохранить часовой пояс.",
+                    reply_markup=menu_keyboard,
+                )
+                return ConversationHandler.END
 
     keyboard = InlineKeyboardMarkup(
         [[InlineKeyboardButton("Далее", callback_data="onb_next")]]
@@ -306,7 +311,11 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         user = session.get(User, user_id)
         if user:
             user.onboarding_complete = True
-            commit_session(session)
+            if not commit_session(session):
+                await query.message.reply_text(
+                    "⚠️ Не удалось сохранить настройки."
+                )
+                return ConversationHandler.END
 
     poll_msg = await query.message.reply_poll(
         "Как вам онбординг?",

--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -335,7 +335,12 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
             )
             return ConversationHandler.END
         user.timezone = raw
-        commit_session(session)
+        if not commit_session(session):
+            await update.message.reply_text(
+                "⚠️ Не удалось сохранить часовой пояс.",
+                reply_markup=menu_keyboard,
+            )
+            return ConversationHandler.END
     await update.message.reply_text(
         "✅ Часовой пояс обновлён.", reply_markup=menu_keyboard
     )
@@ -396,7 +401,11 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             await reminder_handlers.delete_reminder(update, context)
 
         if changed:
-            commit_session(session)
+            if not commit_session(session):
+                await query.message.reply_text(
+                    "⚠️ Не удалось сохранить настройки."
+                )
+                return
             alert = (
                 session.query(Alert)
                 .filter_by(user_id=user_id)


### PR DESCRIPTION
## Summary
- handle commit session failure when updating timezone or security settings
- add commit checks in onboarding flow and skip actions

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689823337fc8832a85791a7c4b8627aa