### PR TITLE
[webapp] Add quick action navigation

### DIFF
--- a/webapp/spa/src/App.tsx
+++ b/webapp/spa/src/App.tsx
@@ -9,6 +9,8 @@ import Home from "./pages/Home";
 import Profile from "./pages/Profile";
 import Reminders from "./pages/Reminders";
 import History from "./pages/History";
+import NewMeasurement from "./pages/NewMeasurement";
+import NewMeal from "./pages/NewMeal";
 import Subscription from "./pages/Subscription";
 import NotFound from "./pages/NotFound";
 
@@ -34,6 +36,8 @@ const AppContent = () => {
       <Route path="/profile" element={<Profile />} />
       <Route path="/reminders" element={<Reminders />} />
       <Route path="/history" element={<History />} />
+      <Route path="/history/new-measurement" element={<NewMeasurement />} />
+      <Route path="/history/new-meal" element={<NewMeal />} />
       <Route path="/subscription" element={<Subscription />} />
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/webapp/spa/src/pages/Home.tsx
+++ b/webapp/spa/src/pages/Home.tsx
@@ -96,10 +96,16 @@ const Home = () => {
         <div className="medical-card animate-fade-in" style={{ animationDelay: '400ms' }}>
           <h3 className="font-semibold text-foreground mb-4">Быстрые действия</h3>
           <div className="grid grid-cols-2 gap-3">
-            <button className="medical-button-secondary py-2 text-sm">
+            <button
+              className="medical-button-secondary py-2 text-sm"
+              onClick={() => navigate('/history/new-measurement')}
+            >
               Записать сахар
             </button>
-            <button className="medical-button-secondary py-2 text-sm">
+            <button
+              className="medical-button-secondary py-2 text-sm"
+              onClick={() => navigate('/history/new-meal')}
+            >
               Добавить еду
             </button>
           </div>

--- a/webapp/spa/src/pages/NewMeal.tsx
+++ b/webapp/spa/src/pages/NewMeal.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { MedicalHeader } from '@/components/MedicalHeader';
+
+const NewMeal = () => {
+  const navigate = useNavigate();
+  const [meal, setMeal] = useState('');
+  const [carbs, setCarbs] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    navigate('/history');
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <MedicalHeader
+        title="Добавить еду"
+        showBack
+        onBack={() => navigate(-1)}
+      />
+      <main className="container mx-auto px-4 py-6">
+        <form onSubmit={handleSubmit} className="medical-card p-4 flex flex-col gap-4">
+          <label className="text-sm font-medium">
+            Название блюда
+            <input
+              className="medical-input mt-2"
+              value={meal}
+              onChange={(e) => setMeal(e.target.value)}
+              placeholder="Например: овсянка"
+            />
+          </label>
+          <label className="text-sm font-medium">
+            Углеводы (г)
+            <input
+              type="number"
+              className="medical-input mt-2"
+              value={carbs}
+              onChange={(e) => setCarbs(e.target.value)}
+            />
+          </label>
+          <button type="submit" className="medical-button w-full">
+            Сохранить
+          </button>
+        </form>
+      </main>
+    </div>
+  );
+};
+
+export default NewMeal;

--- a/webapp/spa/src/pages/NewMeasurement.tsx
+++ b/webapp/spa/src/pages/NewMeasurement.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { MedicalHeader } from '@/components/MedicalHeader';
+
+const NewMeasurement = () => {
+  const navigate = useNavigate();
+  const [sugar, setSugar] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    navigate('/history');
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <MedicalHeader
+        title="Запись сахара"
+        showBack
+        onBack={() => navigate(-1)}
+      />
+      <main className="container mx-auto px-4 py-6">
+        <form onSubmit={handleSubmit} className="medical-card p-4 flex flex-col gap-4">
+          <label className="text-sm font-medium">
+            Уровень сахара
+            <input
+              type="number"
+              step="0.1"
+              className="medical-input mt-2"
+              value={sugar}
+              onChange={(e) => setSugar(e.target.value)}
+              placeholder="ммоль/л"
+            />
+          </label>
+          <button type="submit" className="medical-button w-full">
+            Сохранить
+          </button>
+        </form>
+      </main>
+    </div>
+  );
+};
+
+export default NewMeasurement;


### PR DESCRIPTION
## Summary
- add quick-action handlers to jump to measurement and meal forms
- introduce pages for new sugar and meal records
- register routes for new record pages

## Testing
- `npm run lint` (fails: 4 errors, 7 warnings)
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689850864430832aa8a99493e5807397