### PR TITLE
feat: version webapp url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ DB_PORT=5432
 DB_NAME=diabetes_bot
 DB_USER=diabetes_user
 DB_PASSWORD=
+WEBAPP_URL=
+WEBAPP_VERSION=

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 - `OPENAI_ASSISTANT_ID` – ID ассистента OpenAI
 - `OPENAI_PROXY` – опциональный прокси для запросов к OpenAI
 - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` – настройки базы данных
+- `WEBAPP_URL` – базовый адрес Telegram WebApp
+- `WEBAPP_VERSION` – версия WebApp для пробивания кеша (git SHA или timestamp)
 
 3. Установите зависимости из файла `requirements.txt`:
    ```bash
@@ -43,6 +45,17 @@
   ```bash
   uvicorn api:app --reload
   ```
+
+### Обновление WebApp
+
+Telegram кэширует URL веб‑приложения без параметров. После каждого
+релиза обновляйте значение `WEBAPP_VERSION`, чтобы к адресу WebApp
+добавлялся параметр `?v=…` и Telegram загружал свежую версию. Обычно
+достаточно указать короткий git SHA:
+
+```bash
+export WEBAPP_VERSION=$(git rev-parse --short HEAD)
+```
 
 ## REST API
 

--- a/stubs/telegram/__init__.py
+++ b/stubs/telegram/__init__.py
@@ -17,3 +17,7 @@ class InlineKeyboardMarkup:
     def __init__(self, *a, **k):
         pass
 
+class WebAppInfo:
+    def __init__(self, *a, **k):
+        pass
+


### PR DESCRIPTION
## Summary
- append a version parameter to the Telegram WebApp URL so new deployments bypass cache
- document WEBAPP_URL and WEBAPP_VERSION and how to refresh the WebApp

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689874d37540832a9526d0c2438f6f7d