### PR TITLE
[docker] build ui if needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ EXPOSE 8000
 
 # Установка системных библиотек (PostgreSQL)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libpq-dev gcc && \
+    apt-get install -y --no-install-recommends libpq-dev gcc nodejs npm && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,12 @@ set -e
 
 if [ "$ENABLE_WEBAPP" = "1" ] || [ "$ENABLE_WEBAPP" = "true" ]; then
     if [ -n "$WEBAPP_URL" ] && [[ "$WEBAPP_URL" == https://* ]]; then
+        if [ ! -d "webapp/ui/dist" ]; then
+            echo "Building webapp UI..."
+            (cd webapp/ui && npm ci && npm run build)
+        else
+            echo "webapp UI already built; skipping build"
+        fi
         echo "Starting WebApp at $WEBAPP_URL"
         uvicorn webapp.server:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS:-1} &
     else


### PR DESCRIPTION
## Summary
- install Node.js in runtime image
- auto build webapp UI if dist folder missing on start

## Testing
- `ruff check diabetes tests`
- `pytest tests`
- `PATH=$PWD/fakebin:$PATH ENABLE_WEBAPP=1 WEBAPP_URL=https://example.com bash start.sh` (dist removed)
- `PATH=$PWD/fakebin:$PATH ENABLE_WEBAPP=1 WEBAPP_URL=https://example.com bash start.sh` (dist present)

------
https://chatgpt.com/codex/tasks/task_e_68987b94ae7c832aba7ddf7b1f6ae81f