### PR TITLE
[webapp] enforce UI build at startup

### DIFF
--- a/tests/test_webapp_server_startup.py
+++ b/tests/test_webapp_server_startup.py
@@ -1,0 +1,26 @@
+"""Tests for webapp server startup checks."""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_missing_ui_build_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing server without a built UI should raise an error."""
+    ui_dir = (Path(__file__).resolve().parents[1] / "webapp" / "ui" / "dist").resolve()
+    original_exists = Path.exists
+
+    def fake_exists(self: Path) -> bool:  # noqa: ANN001
+        if self == ui_dir:
+            return False
+        return original_exists(self)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    sys.modules.pop("webapp.server", None)
+    with pytest.raises(RuntimeError):
+        importlib.import_module("webapp.server")
+    monkeypatch.setattr(Path, "exists", original_exists)
+    importlib.import_module("webapp.server")
+

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -23,6 +23,12 @@ BASE_DIR = Path(__file__).parent.resolve()
 # Serve the compiled ``dist`` directory so that the application serves the
 # latest build output under the ``/ui`` path.
 UI_DIR = (BASE_DIR / "ui" / "dist").resolve()
+if not UI_DIR.exists():
+    logger.error(
+        "UI build directory %s not found. Run `npm run build` in webapp/ui",
+        UI_DIR,
+    )
+    raise RuntimeError("UI build not found; run npm run build in webapp/ui")
 
 # store data files outside the served static directory
 STORAGE_DIR = (BASE_DIR.parent / "webapp_data").resolve()


### PR DESCRIPTION
## Summary
- require built UI assets on webapp startup, logging instructions if missing
- add test covering missing build failure

## Testing
- `ruff check webapp tests diabetes`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68987d2718bc832a9f1c290071fd6882