### PR TITLE
[webapp] Handle trailing slash for UI

### DIFF
--- a/webapp/server.py
+++ b/webapp/server.py
@@ -16,6 +16,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, ValidationError
 
 app = FastAPI()
+app.router.redirect_slashes = True
 logger = logging.getLogger(__name__)
 
 BASE_DIR = Path(__file__).parent.resolve()
@@ -196,7 +197,14 @@ if UI_DIR.exists():
 
 
 @app.get("/ui", include_in_schema=False)
+@app.head("/ui", include_in_schema=False)
 async def ui_root() -> FileResponse:
+    return serve_index()
+
+
+@app.get("/ui/", include_in_schema=False)
+@app.head("/ui/", include_in_schema=False)
+async def ui_root_slash() -> FileResponse:
     return serve_index()
 
 


### PR DESCRIPTION
## Summary
- ensure FastAPI redirects slashes and add /ui/ endpoint to serve SPA
- support HEAD requests on /ui and /ui/

## Testing
- `ruff check diabetes tests webapp/server.py`
- `pytest tests/`
- `uvicorn webapp.server:app --port 8000 &` then `curl -I http://localhost:8000/ui` and `curl -I http://localhost:8000/ui/`


------
https://chatgpt.com/codex/tasks/task_e_689895813bf0832ab28bf7151e0cd8c3