### PR TITLE
Ensure timestamps are timezone-aware

### DIFF
--- a/alembic/versions/6f83b831d7c9_add_timezone_to_reminder_time.py
+++ b/alembic/versions/6f83b831d7c9_add_timezone_to_reminder_time.py
@@ -1,0 +1,19 @@
+"""make reminder time timezone aware"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '6f83b831d7c9'
+down_revision: Union[str, None] = 'de2fbeefa646'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column('reminders', 'time', type_=sa.TIMESTAMP(timezone=True))
+
+
+def downgrade() -> None:
+    op.alter_column('reminders', 'time', type_=sa.TIMESTAMP(timezone=False))

--- a/alembic/versions/de2fbeefa646_add_event_time.py
+++ b/alembic/versions/de2fbeefa646_add_event_time.py
@@ -23,9 +23,9 @@ def upgrade() -> None:
         'entries',
         sa.Column(
             'event_time',
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             nullable=False,
-            server_default=sa.text("'2025-01-01 00:00:00'")
+            server_default=sa.text("'2025-01-01 00:00:00+00:00'")
         )
     )
     op.add_column('entries', sa.Column('created_at', sa.TIMESTAMP(), server_default=sa.text('now()'), nullable=True))

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -91,7 +91,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if context.user_data.get('awaiting_report_date'):
         try:
             
-            date_from = datetime.strptime(update.message.text.strip(), "%Y-%m-%d")
+            date_from = datetime.strptime(update.message.text.strip(), "%Y-%m-%d").replace(tzinfo=timezone.utc)
         except Exception:
             await update.message.reply_text("❗ Формат даты: YYYY-MM-DD")
             return
@@ -172,7 +172,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             if "dose" in parts:  entry.dose         = float(parts["dose"])
             if "сахар" in parts or "sugar" in parts:
                 entry.sugar_before = float(parts.get("сахар") or parts["sugar"])
-            entry.updated_at = datetime.utcnow()
+            entry.updated_at = datetime.now(timezone.utc)
             s.commit()
         context.user_data.pop("edit_id")
         context.user_data.pop('pending_entry', None)
@@ -193,14 +193,14 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if time_str:
             try:
                 hh, mm = map(int, time_str.split(":"))
-                now = datetime.now()
-                run_time = datetime.combine(now.date(), dtime(hh, mm))
+                now = datetime.now(timezone.utc)
+                run_time = datetime.combine(now.date(), dtime(hh, mm, tzinfo=timezone.utc))
                 if run_time <= now:
                     run_time += timedelta(days=1)
             except Exception:
-                run_time = datetime.now() + timedelta(minutes=1)
+                run_time = datetime.now(timezone.utc) + timedelta(minutes=1)
         else:
-            run_time = datetime.now() + timedelta(minutes=1)
+            run_time = datetime.now(timezone.utc) + timedelta(minutes=1)
         add_reminder(update.effective_user.id, run_time, message)
         schedule_reminder(context.bot, update.effective_user.id, run_time, message)
         await update.message.reply_text(
@@ -227,10 +227,10 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif time_str:
         try:
             hh, mm = map(int, time_str.split(":"))
-            today  = datetime.now().date()
-            event_dt = datetime.combine(today, dtime(hh, mm))
+            today  = datetime.now(timezone.utc).date()
+            event_dt = datetime.combine(today, dtime(hh, mm, tzinfo=timezone.utc))
         except Exception:
-            event_dt = datetime.now()
+            event_dt = datetime.now(timezone.utc)
     else:
         event_dt = datetime.now(timezone.utc)
 
@@ -1044,7 +1044,7 @@ async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_T
     await query.answer()
     data = query.data
 
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     if data == "report_today":
         date_from = now.replace(hour=0, minute=0, second=0, microsecond=0)
         period_label = "сегодня"
@@ -1069,7 +1069,7 @@ async def report_date_input(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if context.user_data.get('awaiting_report_date'):
         try:
             
-            date_from = datetime.strptime(update.message.text.strip(), "%Y-%m-%d")
+            date_from = datetime.strptime(update.message.text.strip(), "%Y-%m-%d").replace(tzinfo=timezone.utc)
         except Exception:
             await update.message.reply_text("❗ Формат даты: YYYY-MM-DD")
             return

--- a/db.py
+++ b/db.py
@@ -42,7 +42,7 @@ class Entry(Base):
     id          = Column(Integer, primary_key=True, index=True)
     telegram_id = Column(BigInteger, ForeignKey("users.telegram_id"))
 
-    event_time  = Column(TIMESTAMP, nullable=False)          # время приёма пищи / инъекции
+    event_time  = Column(TIMESTAMP(timezone=True), nullable=False)  # время приёма пищи / инъекции
     created_at  = Column(TIMESTAMP, server_default=func.now())
     updated_at  = Column(TIMESTAMP, onupdate=func.now())
 
@@ -59,7 +59,7 @@ class Reminder(Base):
 
     id          = Column(Integer, primary_key=True, index=True)
     telegram_id = Column(BigInteger, ForeignKey("users.telegram_id"))
-    time        = Column(TIMESTAMP, nullable=False)
+    time        = Column(TIMESTAMP(timezone=True), nullable=False)
     message     = Column(Text, nullable=False)
     created_at  = Column(TIMESTAMP, server_default=func.now())
 

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import create_engine
@@ -29,7 +29,7 @@ def session(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_reminder_creation_and_trigger(session):
-    run_time = datetime.now() + timedelta(seconds=1)
+    run_time = datetime.now(timezone.utc) + timedelta(seconds=1)
     db_access.add_reminder(1, run_time, "check sugar")
     reminders = db_access.get_reminders(1)
     assert len(reminders) == 1


### PR DESCRIPTION
## Summary
- Store entry and reminder times as `TIMESTAMP WITH TIME ZONE`
- Generate UTC-aware datetimes in handlers and tests
- Add migrations to migrate existing columns to timezone-aware types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a0410994832a94793ad69eaa245f