### PR TITLE
Handle invalid JSON in command parser

### DIFF
--- a/gpt_command_parser.py
+++ b/gpt_command_parser.py
@@ -74,7 +74,11 @@ async def parse_command(text: str) -> dict | None:
             return None
         content = choices[0].message.content.strip()
         logging.info(f"GPT parse response: {content}")
-        return json.loads(content)
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            logging.error(f"Invalid JSON response: {content}")
+            return None
     except Exception as e:
         logging.error(f"Command parsing failed: {e}")
         return None


### PR DESCRIPTION
## Summary
- avoid crashes on invalid GPT output by logging JSON decode errors and returning `None`

## Testing
- `flake8 gpt_command_parser.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898a4559494832a88c6f0d7d1f6c45c