### PR TITLE
[ui] Add Modal component

### DIFF
--- a/webapp/ui/src/components/Modal.tsx
+++ b/webapp/ui/src/components/Modal.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  footer?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const Modal = ({ isOpen, onClose, title, footer, children }: ModalProps) => {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    const root = document.documentElement;
+    const previousOverflow = root.style.overflow;
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      root.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      root.style.overflow = previousOverflow;
+    };
+  }, [isOpen, onClose]);
+
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === overlayRef.current) {
+      onClose();
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={overlayRef}
+      onMouseDown={handleOverlayClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div className="relative w-full max-w-lg mx-4 bg-background rounded-lg shadow-lg">
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          {title && <h2 className="text-lg font-semibold">{title}</h2>}
+          <button
+            onClick={onClose}
+            className="p-2 rounded-md hover:bg-secondary/80 transition-colors"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <div className="p-4">{children}</div>
+        {footer && <div className="p-4 border-t border-border">{footer}</div>}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;


### PR DESCRIPTION
## Summary
- add reusable Modal component with close button, header and footer slot
- handle ESC and overlay click with scroll locking

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6898ac5b38b0832aa2c1b9f56f0313be