### PR TITLE
[webapp] Import theme styles

### DIFF
--- a/webapp/ui/src/main.tsx
+++ b/webapp/ui/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import './styles/theme.css'
 import '@static/style.css'
 import '@static/telegram-init.js'
 


### PR DESCRIPTION
## Summary
- import global theme stylesheet before app render

## Testing
- `ruff check diabetes tests`
- `pytest tests`
- `npm --prefix webapp/ui run build`
- `grep -o -- '--bg-color' webapp/ui/dist/assets/index-CA9EeHCY.css | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6898b41260ec832a89009b596d503b2b