### PR TITLE
[ui] Refactor reminder form with Modal and SegmentedControl

### DIFF
--- a/webapp/ui/src/components/Modal.tsx
+++ b/webapp/ui/src/components/Modal.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useRef } from 'react';
 
 interface ModalProps {
-  isOpen: boolean;
+  open: boolean;
   onClose: () => void;
   title?: string;
   footer?: React.ReactNode;
   children: React.ReactNode;
 }
 
-const Modal = ({ isOpen, onClose, title, footer, children }: ModalProps) => {
+const Modal = ({ open, onClose, title, footer, children }: ModalProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -21,7 +21,7 @@ const Modal = ({ isOpen, onClose, title, footer, children }: ModalProps) => {
     const root = document.documentElement;
     const previousOverflow = root.style.overflow;
 
-    if (isOpen) {
+    if (open) {
       document.addEventListener('keydown', handleKeyDown);
       root.style.overflow = 'hidden';
     }
@@ -30,7 +30,7 @@ const Modal = ({ isOpen, onClose, title, footer, children }: ModalProps) => {
       document.removeEventListener('keydown', handleKeyDown);
       root.style.overflow = previousOverflow;
     };
-  }, [isOpen, onClose]);
+  }, [open, onClose]);
 
   const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === overlayRef.current) {
@@ -38,7 +38,7 @@ const Modal = ({ isOpen, onClose, title, footer, children }: ModalProps) => {
     }
   };
 
-  if (!isOpen) {
+  if (!open) {
     return null;
   }
 

--- a/webapp/ui/src/components/ReminderForm.tsx
+++ b/webapp/ui/src/components/ReminderForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Modal, SegmentedControl } from '@/components';
 
 const reminderTypes = {
   sugar: { label: 'Измерение сахара', icon: '🩸' },
@@ -43,78 +43,74 @@ const ReminderForm = ({ open, onOpenChange, initialData, onSubmit }: ReminderFor
     onSubmit(form);
   };
 
+  const footer = (
+    <div className="flex gap-3">
+      <button type="submit" form="reminder-form" className="medical-button flex-1">
+        Сохранить
+      </button>
+      <button
+        type="button"
+        onClick={() => onOpenChange(false)}
+        className="medical-button-secondary flex-1"
+      >
+        Отмена
+      </button>
+    </div>
+  );
+
+  const segmentedItems = Object.entries(reminderTypes).map(([key, info]) => ({
+    value: key,
+    icon: info.icon,
+    label: info.label
+  }));
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>
-            {initialData ? 'Редактирование напоминания' : 'Новое напоминание'}
-          </DialogTitle>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
-              Тип напоминания
-            </label>
-            <div className="grid grid-cols-2 gap-2">
-              {Object.entries(reminderTypes).map(([key, info]) => (
-                <button
-                  key={key}
-                  type="button"
-                  onClick={() => setForm(prev => ({ ...prev, type: key as keyof typeof reminderTypes }))}
-                  className={`p-3 rounded-lg border transition-all duration-200 ${
-                    form.type === key
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-border hover:bg-secondary/50'
-                  }`}
-                >
-                  <div className="text-lg mb-1">{info.icon}</div>
-                  <div className="text-xs">{info.label}</div>
-                </button>
-              ))}
-            </div>
-          </div>
+    <Modal
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title={initialData ? 'Редактирование напоминания' : 'Новое напоминание'}
+      footer={footer}
+    >
+      <form id="reminder-form" onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-2">
+            Тип напоминания
+          </label>
+          <SegmentedControl
+            value={form.type}
+            onChange={value =>
+              setForm(prev => ({ ...prev, type: value as keyof typeof reminderTypes }))
+            }
+            items={segmentedItems}
+          />
+        </div>
 
-          <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
-              Название
-            </label>
-            <input
-              type="text"
-              value={form.title}
-              onChange={e => setForm(prev => ({ ...prev, title: e.target.value }))}
-              className="medical-input"
-              placeholder="Например: Измерение сахара"
-            />
-          </div>
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-2">
+            Название
+          </label>
+          <input
+            type="text"
+            value={form.title}
+            onChange={e => setForm(prev => ({ ...prev, title: e.target.value }))}
+            className="medical-input"
+            placeholder="Например: Измерение сахара"
+          />
+        </div>
 
-          <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
-              Время
-            </label>
-            <input
-              type="time"
-              value={form.time}
-              onChange={e => setForm(prev => ({ ...prev, time: e.target.value }))}
-              className="medical-input"
-            />
-          </div>
-
-          <div className="flex gap-3 pt-2">
-            <button type="submit" className="medical-button flex-1">
-              Сохранить
-            </button>
-            <button
-              type="button"
-              onClick={() => onOpenChange(false)}
-              className="medical-button-secondary flex-1"
-            >
-              Отмена
-            </button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-2">
+            Время
+          </label>
+          <input
+            type="time"
+            value={form.time}
+            onChange={e => setForm(prev => ({ ...prev, time: e.target.value }))}
+            className="medical-input"
+          />
+        </div>
+      </form>
+    </Modal>
   );
 };
 

--- a/webapp/ui/src/components/index.ts
+++ b/webapp/ui/src/components/index.ts
@@ -1,0 +1,2 @@
+export { default as Modal } from './Modal';
+export { SegmentedControl } from './SegmentedControl';


### PR DESCRIPTION
## Summary
- expose Modal and SegmentedControl from components barrel
- refactor Modal to use `open` prop
- rewrite ReminderForm to use Modal and SegmentedControl for type selection

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6898b667eb40832aab46a8e65f28387e