### PR TITLE
[ui] Set button default type

### DIFF
--- a/webapp/ui/src/components/ui/button.tsx
+++ b/webapp/ui/src/components/ui/button.tsx
@@ -40,12 +40,13 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, type, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        type={asChild ? type : type ?? "button"}
         {...props}
       />
     )


### PR DESCRIPTION
## Summary
- set default `type="button"` for Button component while allowing override

## Testing
- `npx eslint src/components/ui/button.tsx`
- `ruff check diabetes tests`
- `pytest tests`
- `npm run lint` *(fails: existing lint errors outside modified file)*

------
https://chatgpt.com/codex/tasks/task_e_6898c2a6fc8c832abd226c700f3603b4