### PR TITLE
[ui] Add focus-visible and disabled states to medical buttons

### DIFF
--- a/webapp/ui/src/components/ReminderForm.tsx
+++ b/webapp/ui/src/components/ReminderForm.tsx
@@ -43,9 +43,16 @@ const ReminderForm = ({ open, onOpenChange, initialData, onSubmit }: ReminderFor
     onSubmit(form);
   };
 
+  const isDisabled = !form.title || !form.time;
+
   const footer = (
     <div className="flex gap-3">
-      <button type="submit" form="reminder-form" className="medical-button flex-1">
+      <button
+        type="submit"
+        form="reminder-form"
+        className="medical-button flex-1"
+        disabled={isDisabled}
+      >
         Сохранить
       </button>
       <button

--- a/webapp/ui/src/index.css
+++ b/webapp/ui/src/index.css
@@ -175,16 +175,20 @@
   }
   
   .medical-button {
-    @apply bg-gradient-to-r from-primary to-primary/90 text-primary-foreground 
+    @apply bg-gradient-to-r from-primary to-primary/90 text-primary-foreground
            font-medium px-6 py-3 rounded-xl border-0 shadow-[var(--shadow-soft)]
-           hover:shadow-[var(--shadow-medium)] active:scale-95 
-           transition-all duration-200 touch-manipulation;
+           hover:shadow-[var(--shadow-medium)] active:scale-95
+           transition-all duration-200 touch-manipulation
+           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+           disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none disabled:active:scale-100;
   }
-  
+
   .medical-button-secondary {
-    @apply bg-secondary text-secondary-foreground font-medium px-6 py-3 rounded-xl 
-           border border-border hover:bg-secondary/80 active:scale-95 
-           transition-all duration-200 touch-manipulation;
+    @apply bg-secondary text-secondary-foreground font-medium px-6 py-3 rounded-xl
+           border border-border hover:bg-secondary/80 active:scale-95
+           transition-all duration-200 touch-manipulation
+           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+           disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-secondary disabled:active:scale-100 disabled:shadow-none;
   }
   
   .medical-input {

--- a/webapp/ui/src/pages/NewMeal.tsx
+++ b/webapp/ui/src/pages/NewMeal.tsx
@@ -39,7 +39,11 @@ const NewMeal = () => {
               onChange={(e) => setCarbs(e.target.value)}
             />
           </label>
-          <button type="submit" className="medical-button w-full">
+          <button
+            type="submit"
+            className="medical-button w-full"
+            disabled={!meal || !carbs}
+          >
             Сохранить
           </button>
         </form>

--- a/webapp/ui/src/pages/NewMeasurement.tsx
+++ b/webapp/ui/src/pages/NewMeasurement.tsx
@@ -31,7 +31,11 @@ const NewMeasurement = () => {
               placeholder="ммоль/л"
             />
           </label>
-          <button type="submit" className="medical-button w-full">
+          <button
+            type="submit"
+            className="medical-button w-full"
+            disabled={!sugar}
+          >
             Сохранить
           </button>
         </form>

--- a/webapp/ui/src/pages/Subscription.tsx
+++ b/webapp/ui/src/pages/Subscription.tsx
@@ -11,7 +11,7 @@ interface TariffPlan {
   description: string;
   features: string[];
   recommended?: boolean;
-  icon: React.ComponentType<any>;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   color: string;
 }
 
@@ -154,6 +154,7 @@ const Subscription = () => {
                     
                     <button
                       onClick={() => handleSubscribe(plan.id)}
+                      disabled={plan.price === '0'}
                       className={`w-full py-3 px-6 rounded-xl font-medium transition-all duration-200 touch-manipulation ${
                         plan.recommended
                           ? 'medical-button'


### PR DESCRIPTION
## Summary
- add focus-visible rings and disabled styles to `.medical-button` and `.medical-button-secondary`
- disable action buttons when required inputs are empty
- prevent subscribing to current free plan and tighten TariffPlan icon typing

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in ui components, unrelated to changes)*
- `ruff check diabetes tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898c435bd08832a81b6d15040f1544e