### PR TITLE
[ui] replace medical button classes with button component

### DIFF
--- a/webapp/ui/src/components/ReminderForm.tsx
+++ b/webapp/ui/src/components/ReminderForm.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Modal, SegmentedControl } from '@/components';
+import { Button } from '@/components/ui/button';
 
 const reminderTypes = {
   sugar: { label: 'Измерение сахара', icon: '🩸' },
@@ -47,21 +48,24 @@ const ReminderForm = ({ open, onOpenChange, initialData, onSubmit }: ReminderFor
 
   const footer = (
     <div className="flex gap-3">
-      <button
+      <Button
         type="submit"
         form="reminder-form"
-        className="medical-button flex-1"
+        className="flex-1"
         disabled={isDisabled}
+        size="lg"
       >
         Сохранить
-      </button>
-      <button
+      </Button>
+      <Button
         type="button"
         onClick={() => onOpenChange(false)}
-        className="medical-button-secondary flex-1"
+        variant="secondary"
+        className="flex-1"
+        size="lg"
       >
         Отмена
-      </button>
+      </Button>
     </div>
   );
 

--- a/webapp/ui/src/components/ui/button.tsx
+++ b/webapp/ui/src/components/ui/button.tsx
@@ -5,24 +5,25 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-gradient-to-r from-primary to-primary/90 text-primary-foreground shadow-[var(--shadow-soft)] hover:shadow-[var(--shadow-medium)] active:scale-95 disabled:shadow-none",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground border border-border hover:bg-secondary/80 active:scale-95",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-10 px-4 py-2",
         sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        lg: "rounded-xl px-6 py-3",
         icon: "h-10 w-10",
       },
     },

--- a/webapp/ui/src/index.css
+++ b/webapp/ui/src/index.css
@@ -174,23 +174,6 @@
            hover:shadow-[var(--shadow-medium)] transition-all duration-200;
   }
   
-  .medical-button {
-    @apply bg-gradient-to-r from-primary to-primary/90 text-primary-foreground
-           font-medium px-6 py-3 rounded-xl border-0 shadow-[var(--shadow-soft)]
-           hover:shadow-[var(--shadow-medium)] active:scale-95
-           transition-all duration-200 touch-manipulation
-           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
-           disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none disabled:active:scale-100;
-  }
-
-  .medical-button-secondary {
-    @apply bg-secondary text-secondary-foreground font-medium px-6 py-3 rounded-xl
-           border border-border hover:bg-secondary/80 active:scale-95
-           transition-all duration-200 touch-manipulation
-           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
-           disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-secondary disabled:active:scale-100 disabled:shadow-none;
-  }
-  
   .medical-input {
     @apply w-full px-4 py-3 bg-card border border-input rounded-xl text-foreground
            placeholder:text-muted-foreground focus:outline-none focus:ring-2 

--- a/webapp/ui/src/pages/History.tsx
+++ b/webapp/ui/src/pages/History.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Calendar, TrendingUp, Edit2, Trash2, Filter } from 'lucide-react';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useToast } from '@/hooks/use-toast';
+import { Button } from '@/components/ui/button';
 
 interface HistoryRecord {
   id: string;
@@ -430,20 +431,23 @@ const History = () => {
               </div>
 
               <div className="flex gap-3 pt-2">
-                <button
+                <Button
                   type="button"
                   onClick={handleUpdateRecord}
-                  className="medical-button flex-1"
+                  className="flex-1"
+                  size="lg"
                 >
                   Сохранить
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
                   onClick={() => setEditingRecord(null)}
-                  className="medical-button-secondary flex-1"
+                  variant="secondary"
+                  className="flex-1"
+                  size="lg"
                 >
                   Отмена
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -464,13 +468,14 @@ const History = () => {
 
         {/* Кнопка аналитики */}
         <div className="mt-8">
-          <button
+          <Button
             onClick={() => navigate('/analytics')}
-            className="medical-button w-full flex items-center justify-center gap-2"
+            className="w-full flex items-center justify-center gap-2"
+            size="lg"
           >
             <TrendingUp className="w-4 h-4" />
             Посмотреть аналитику
-          </button>
+          </Button>
         </div>
       </main>
     </div>

--- a/webapp/ui/src/pages/Home.tsx
+++ b/webapp/ui/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { Clock, User, BookOpen, Star } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useTelegram } from '@/hooks/useTelegram';
+import { Button } from '@/components/ui/button';
 
 const menuItems = [
   {
@@ -96,18 +97,22 @@ const Home = () => {
         <div className="medical-card animate-fade-in" style={{ animationDelay: '400ms' }}>
           <h3 className="font-semibold text-foreground mb-4">Быстрые действия</h3>
           <div className="grid grid-cols-2 gap-3">
-            <button
-              className="medical-button-secondary py-2 text-sm"
+            <Button
+              variant="secondary"
+              size="lg"
+              className="py-2 text-sm"
               onClick={() => navigate('/history/new-measurement')}
             >
               Записать сахар
-            </button>
-            <button
-              className="medical-button-secondary py-2 text-sm"
+            </Button>
+            <Button
+              variant="secondary"
+              size="lg"
+              className="py-2 text-sm"
               onClick={() => navigate('/history/new-meal')}
             >
               Добавить еду
-            </button>
+            </Button>
           </div>
         </div>
 

--- a/webapp/ui/src/pages/NewMeal.tsx
+++ b/webapp/ui/src/pages/NewMeal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MedicalHeader } from '@/components/MedicalHeader';
+import { Button } from '@/components/ui/button';
 
 const NewMeal = () => {
   const navigate = useNavigate();
@@ -39,13 +40,14 @@ const NewMeal = () => {
               onChange={(e) => setCarbs(e.target.value)}
             />
           </label>
-          <button
+          <Button
             type="submit"
-            className="medical-button w-full"
+            className="w-full"
             disabled={!meal || !carbs}
+            size="lg"
           >
             Сохранить
-          </button>
+          </Button>
         </form>
       </main>
     </div>

--- a/webapp/ui/src/pages/NewMeasurement.tsx
+++ b/webapp/ui/src/pages/NewMeasurement.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MedicalHeader } from '@/components/MedicalHeader';
+import { Button } from '@/components/ui/button';
 
 const NewMeasurement = () => {
   const navigate = useNavigate();
@@ -31,13 +32,14 @@ const NewMeasurement = () => {
               placeholder="ммоль/л"
             />
           </label>
-          <button
+          <Button
             type="submit"
-            className="medical-button w-full"
+            className="w-full"
             disabled={!sugar}
+            size="lg"
           >
             Сохранить
-          </button>
+          </Button>
         </form>
       </main>
     </div>

--- a/webapp/ui/src/pages/Profile.tsx
+++ b/webapp/ui/src/pages/Profile.tsx
@@ -4,6 +4,7 @@ import { Save } from 'lucide-react';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useTelegram } from '@/hooks/useTelegram';
 import { useToast } from '@/hooks/use-toast';
+import { Button } from '@/components/ui/button';
 
 const Profile = () => {
   const navigate = useNavigate();
@@ -149,13 +150,14 @@ const Profile = () => {
             </div>
 
             {/* Кнопка сохранения */}
-            <button
+            <Button
               onClick={handleSave}
-              className="medical-button w-full flex items-center justify-center gap-2"
+              className="w-full flex items-center justify-center gap-2"
+              size="lg"
             >
               <Save className="w-4 h-4" />
               Сохранить настройки
-            </button>
+            </Button>
           </div>
         </div>
 

--- a/webapp/ui/src/pages/Reminders.tsx
+++ b/webapp/ui/src/pages/Reminders.tsx
@@ -5,6 +5,7 @@ import { MedicalHeader } from '@/components/MedicalHeader';
 import { useToast } from '@/hooks/use-toast';
 import ReminderForm, { ReminderFormValues } from '@/components/ReminderForm';
 import { createReminder, updateReminder } from '@/api/reminders';
+import { Button } from '@/components/ui/button';
 
 interface Reminder {
   id: string;
@@ -219,15 +220,15 @@ const Reminders = () => {
             <p className="text-muted-foreground mb-6">
               Добавьте первое напоминание для контроля диабета
             </p>
-            <button
+            <Button
               onClick={() => {
                 setEditingReminder(null);
                 setFormOpen(true);
               }}
-              className="medical-button"
+              size="lg"
             >
               Создать напоминание
-            </button>
+            </Button>
           </div>
         )}
       </main>

--- a/webapp/ui/src/pages/Subscription.tsx
+++ b/webapp/ui/src/pages/Subscription.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { Check, Star, Users, Zap } from 'lucide-react';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useToast } from '@/hooks/use-toast';
+import { Button } from '@/components/ui/button';
 
 interface TariffPlan {
   id: string;
@@ -152,17 +153,15 @@ const Subscription = () => {
                       ))}
                     </div>
                     
-                    <button
+                    <Button
                       onClick={() => handleSubscribe(plan.id)}
                       disabled={plan.price === '0'}
-                      className={`w-full py-3 px-6 rounded-xl font-medium transition-all duration-200 touch-manipulation ${
-                        plan.recommended
-                          ? 'medical-button'
-                          : 'medical-button-secondary'
-                      }`}
+                      className="w-full"
+                      size="lg"
+                      variant={plan.recommended ? 'default' : 'secondary'}
                     >
                       {plan.price === '0' ? 'Текущий тариф' : 'Выбрать тариф'}
-                    </button>
+                    </Button>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- map old medical-button styles into new Button variants
- switch forms and pages to use unified Button component
- remove unused medical-button classes

## Testing
- `npm --prefix webapp/ui run lint` *(fails: react-refresh/only-export-components, @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6898cb406c0c832aba0736dafe4fabc6