### PR TITLE
[webapp] use MedicalButton for consistent styling

### DIFF
--- a/webapp/ui/src/components/MedicalButton.tsx
+++ b/webapp/ui/src/components/MedicalButton.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Button, type ButtonProps } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface MedicalButtonProps extends Omit<ButtonProps, 'variant'> {
+  variant?: 'primary' | 'secondary' | 'icon';
+}
+
+const MedicalButton = React.forwardRef<HTMLButtonElement, MedicalButtonProps>(
+  ({ variant = 'primary', className, size, ...props }, ref) => {
+    const buttonVariant = variant === 'secondary' ? 'secondary' : 'default';
+    const buttonSize = variant === 'icon' ? 'icon' : size ?? 'lg';
+
+    return (
+      <Button
+        ref={ref}
+        variant={buttonVariant}
+        size={buttonSize}
+        className={cn(variant === 'icon' && 'rounded-lg', className)}
+        {...props}
+      />
+    );
+  }
+);
+
+MedicalButton.displayName = 'MedicalButton';
+
+export { MedicalButton };
+export default MedicalButton;

--- a/webapp/ui/src/components/index.ts
+++ b/webapp/ui/src/components/index.ts
@@ -1,2 +1,3 @@
 export { default as Modal } from './Modal';
 export { SegmentedControl } from './SegmentedControl';
+export { default as MedicalButton } from './MedicalButton';

--- a/webapp/ui/src/pages/History.tsx
+++ b/webapp/ui/src/pages/History.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Calendar, TrendingUp, Edit2, Trash2, Filter } from 'lucide-react';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useToast } from '@/hooks/use-toast';
-import { Button } from '@/components/ui/button';
+import MedicalButton from '@/components/MedicalButton';
 
 interface HistoryRecord {
   id: string;
@@ -230,23 +230,25 @@ const History = () => {
                     </div>
                     
                     <div className="flex items-center gap-2">
-                      <button
+                      <MedicalButton
+                        variant="icon"
                         onClick={() => handleEditRecord(record)}
-                        className="p-1 rounded hover:bg-secondary transition-all duration-200"
+                        className="bg-transparent hover:bg-secondary text-muted-foreground border-0 p-1"
                         aria-label="Редактировать"
                       >
-                        <Edit2 className="w-3 h-3 text-muted-foreground" />
-                      </button>
-                      <button
+                        <Edit2 className="w-3 h-3" />
+                      </MedicalButton>
+                      <MedicalButton
+                        variant="icon"
                         onClick={() => handleDeleteRecord(record.id)}
-                        className="p-1 rounded hover:bg-destructive/10 hover:text-destructive transition-all duration-200"
+                        className="bg-transparent hover:bg-destructive/10 hover:text-destructive text-muted-foreground border-0 p-1"
                         aria-label="Удалить"
                       >
                         <Trash2 className="w-3 h-3" />
-                      </button>
+                      </MedicalButton>
                     </div>
                   </div>
-                  
+
                   <div className="grid grid-cols-4 gap-4 text-sm mb-2">
                     {record.sugar && (
                       <div>
@@ -431,15 +433,15 @@ const History = () => {
               </div>
 
               <div className="flex gap-3 pt-2">
-                <Button
+                <MedicalButton
                   type="button"
                   onClick={handleUpdateRecord}
                   className="flex-1"
                   size="lg"
                 >
                   Сохранить
-                </Button>
-                <Button
+                </MedicalButton>
+                <MedicalButton
                   type="button"
                   onClick={() => setEditingRecord(null)}
                   variant="secondary"
@@ -447,7 +449,7 @@ const History = () => {
                   size="lg"
                 >
                   Отмена
-                </Button>
+                </MedicalButton>
               </div>
             </div>
           </div>
@@ -468,14 +470,14 @@ const History = () => {
 
         {/* Кнопка аналитики */}
         <div className="mt-8">
-          <Button
+          <MedicalButton
             onClick={() => navigate('/analytics')}
             className="w-full flex items-center justify-center gap-2"
             size="lg"
           >
             <TrendingUp className="w-4 h-4" />
             Посмотреть аналитику
-          </Button>
+          </MedicalButton>
         </div>
       </main>
     </div>

--- a/webapp/ui/src/pages/Home.tsx
+++ b/webapp/ui/src/pages/Home.tsx
@@ -2,7 +2,7 @@ import { Clock, User, BookOpen, Star } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useTelegram } from '@/hooks/useTelegram';
-import { Button } from '@/components/ui/button';
+import MedicalButton from '@/components/MedicalButton';
 
 const menuItems = [
   {
@@ -97,22 +97,22 @@ const Home = () => {
         <div className="medical-card animate-fade-in" style={{ animationDelay: '400ms' }}>
           <h3 className="font-semibold text-foreground mb-4">Быстрые действия</h3>
           <div className="grid grid-cols-2 gap-3">
-            <Button
+            <MedicalButton
               variant="secondary"
               size="lg"
               className="py-2 text-sm"
               onClick={() => navigate('/history/new-measurement')}
             >
               Записать сахар
-            </Button>
-            <Button
+            </MedicalButton>
+            <MedicalButton
               variant="secondary"
               size="lg"
               className="py-2 text-sm"
               onClick={() => navigate('/history/new-meal')}
             >
               Добавить еду
-            </Button>
+            </MedicalButton>
           </div>
         </div>
 

--- a/webapp/ui/src/pages/NewMeal.tsx
+++ b/webapp/ui/src/pages/NewMeal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MedicalHeader } from '@/components/MedicalHeader';
-import { Button } from '@/components/ui/button';
+import MedicalButton from '@/components/MedicalButton';
 
 const NewMeal = () => {
   const navigate = useNavigate();
@@ -40,14 +40,14 @@ const NewMeal = () => {
               onChange={(e) => setCarbs(e.target.value)}
             />
           </label>
-          <Button
+          <MedicalButton
             type="submit"
             className="w-full"
             disabled={!meal || !carbs}
             size="lg"
           >
             Сохранить
-          </Button>
+          </MedicalButton>
         </form>
       </main>
     </div>

--- a/webapp/ui/src/pages/NewMeasurement.tsx
+++ b/webapp/ui/src/pages/NewMeasurement.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MedicalHeader } from '@/components/MedicalHeader';
-import { Button } from '@/components/ui/button';
+import MedicalButton from '@/components/MedicalButton';
 
 const NewMeasurement = () => {
   const navigate = useNavigate();
@@ -32,14 +32,14 @@ const NewMeasurement = () => {
               placeholder="ммоль/л"
             />
           </label>
-          <Button
+          <MedicalButton
             type="submit"
             className="w-full"
             disabled={!sugar}
             size="lg"
           >
             Сохранить
-          </Button>
+          </MedicalButton>
         </form>
       </main>
     </div>

--- a/webapp/ui/src/pages/Profile.tsx
+++ b/webapp/ui/src/pages/Profile.tsx
@@ -4,7 +4,7 @@ import { Save } from 'lucide-react';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useTelegram } from '@/hooks/useTelegram';
 import { useToast } from '@/hooks/use-toast';
-import { Button } from '@/components/ui/button';
+import MedicalButton from '@/components/MedicalButton';
 
 const Profile = () => {
   const navigate = useNavigate();
@@ -150,14 +150,14 @@ const Profile = () => {
             </div>
 
             {/* Кнопка сохранения */}
-            <Button
+            <MedicalButton
               onClick={handleSave}
               className="w-full flex items-center justify-center gap-2"
               size="lg"
             >
               <Save className="w-4 h-4" />
               Сохранить настройки
-            </Button>
+            </MedicalButton>
           </div>
         </div>
 

--- a/webapp/ui/src/pages/Reminders.tsx
+++ b/webapp/ui/src/pages/Reminders.tsx
@@ -5,7 +5,8 @@ import { MedicalHeader } from '@/components/MedicalHeader';
 import { useToast } from '@/hooks/use-toast';
 import ReminderForm, { ReminderFormValues } from '@/components/ReminderForm';
 import { createReminder, updateReminder } from '@/api/reminders';
-import { Button } from '@/components/ui/button';
+import MedicalButton from '@/components/MedicalButton';
+import { cn } from '@/lib/utils';
 
 interface Reminder {
   id: string;
@@ -118,16 +119,17 @@ const Reminders = () => {
         showBack 
         onBack={() => navigate('/')}
       >
-        <button
+        <MedicalButton
+          variant="icon"
           onClick={() => {
             setEditingReminder(null);
             setFormOpen(true);
           }}
-          className="p-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 active:scale-95 transition-all duration-200"
+          className="bg-primary text-primary-foreground hover:bg-primary/90 border-0"
           aria-label="Добавить напоминание"
         >
           <Plus className="w-5 h-5" />
-        </button>
+        </MedicalButton>
       </MedicalHeader>
       
       <main className="container mx-auto px-4 py-6">
@@ -164,34 +166,38 @@ const Reminders = () => {
                   </div>
                   
                   <div className="flex items-center gap-2">
-                    <button
+                    <MedicalButton
+                      variant="icon"
                       onClick={() => handleToggleReminder(reminder.id)}
-                      className={`p-2 rounded-lg transition-all duration-200 ${
+                      className={cn(
+                        'border-0',
                         reminder.active
                           ? 'bg-success/10 text-success'
                           : 'bg-secondary text-muted-foreground'
-                      }`}
+                      )}
                       aria-label={reminder.active ? 'Отключить напоминание' : 'Включить напоминание'}
                     >
                       <Bell className="w-4 h-4" />
-                    </button>
-                    <button
+                    </MedicalButton>
+                    <MedicalButton
+                      variant="icon"
                       onClick={() => {
                         setEditingReminder(reminder);
                         setFormOpen(true);
                       }}
-                      className="p-2 rounded-lg hover:bg-secondary transition-all duration-200"
+                      className="bg-transparent hover:bg-secondary text-muted-foreground border-0"
                       aria-label="Редактировать"
                     >
-                      <Edit2 className="w-4 h-4 text-muted-foreground" />
-                    </button>
-                    <button
+                      <Edit2 className="w-4 h-4" />
+                    </MedicalButton>
+                    <MedicalButton
+                      variant="icon"
                       onClick={() => handleDeleteReminder(reminder.id)}
-                      className="p-2 rounded-lg hover:bg-destructive/10 hover:text-destructive transition-all duration-200"
+                      className="bg-transparent hover:bg-destructive/10 hover:text-destructive text-muted-foreground border-0"
                       aria-label="Удалить"
                     >
                       <Trash2 className="w-4 h-4" />
-                    </button>
+                    </MedicalButton>
                   </div>
                 </div>
               </div>
@@ -220,7 +226,7 @@ const Reminders = () => {
             <p className="text-muted-foreground mb-6">
               Добавьте первое напоминание для контроля диабета
             </p>
-            <Button
+            <MedicalButton
               onClick={() => {
                 setEditingReminder(null);
                 setFormOpen(true);
@@ -228,7 +234,7 @@ const Reminders = () => {
               size="lg"
             >
               Создать напоминание
-            </Button>
+            </MedicalButton>
           </div>
         )}
       </main>

--- a/webapp/ui/src/pages/Subscription.tsx
+++ b/webapp/ui/src/pages/Subscription.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { Check, Star, Users, Zap } from 'lucide-react';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useToast } from '@/hooks/use-toast';
-import { Button } from '@/components/ui/button';
+import MedicalButton from '@/components/MedicalButton';
 
 interface TariffPlan {
   id: string;
@@ -153,15 +153,15 @@ const Subscription = () => {
                       ))}
                     </div>
                     
-                    <Button
+                    <MedicalButton
                       onClick={() => handleSubscribe(plan.id)}
                       disabled={plan.price === '0'}
                       className="w-full"
                       size="lg"
-                      variant={plan.recommended ? 'default' : 'secondary'}
+                      variant={plan.recommended ? 'primary' : 'secondary'}
                     >
                       {plan.price === '0' ? 'Текущий тариф' : 'Выбрать тариф'}
-                    </Button>
+                    </MedicalButton>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add MedicalButton wrapper around shadcn button
- replace button classes on Home, History, Reminders, Profile, NewMeal, NewMeasurement and Subscription pages

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6898cfb90168832aa46dfac2d0a283c4