### PR TITLE
[ui] Use Button component for modal and header

### DIFF
--- a/webapp/ui/src/components/MedicalHeader.tsx
+++ b/webapp/ui/src/components/MedicalHeader.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 
 interface MedicalHeaderProps {
   title: string;
@@ -14,13 +15,14 @@ export const MedicalHeader = ({ title, showBack, onBack, children }: MedicalHead
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             {showBack && (
-              <button
+              <Button
                 onClick={onBack}
-                className="p-2 rounded-lg hover:bg-secondary/80 active:scale-95 transition-all duration-200"
+                variant="ghost"
+                size="icon"
                 aria-label="Назад"
               >
                 <ArrowLeft className="w-5 h-5" />
-              </button>
+              </Button>
             )}
             <h1 className="text-xl font-semibold text-foreground">{title}</h1>
           </div>

--- a/webapp/ui/src/components/Modal.tsx
+++ b/webapp/ui/src/components/Modal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { Button } from '@/components/ui/button';
 
 interface ModalProps {
   open: boolean;
@@ -51,13 +52,14 @@ const Modal = ({ open, onClose, title, footer, children }: ModalProps) => {
       <div className="relative w-full max-w-lg mx-4 bg-background rounded-lg shadow-lg">
         <div className="flex items-center justify-between p-4 border-b border-border">
           {title && <h2 className="text-lg font-semibold">{title}</h2>}
-          <button
+          <Button
             onClick={onClose}
-            className="p-2 rounded-md hover:bg-secondary/80 transition-colors"
+            variant="ghost"
+            size="icon"
             aria-label="Close"
           >
             ×
-          </button>
+          </Button>
         </div>
         <div className="p-4">{children}</div>
         {footer && <div className="p-4 border-t border-border">{footer}</div>}
@@ -67,3 +69,4 @@ const Modal = ({ open, onClose, title, footer, children }: ModalProps) => {
 };
 
 export default Modal;
+


### PR DESCRIPTION
## Summary
- refactor modal close control to use shared Button component
- replace MedicalHeader back control with Button for consistency

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, A require() style import is forbidden)*
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6898d46b501c832a9946977f03c8bbff