### PR TITLE
[webapp] Prefix profile and reminders endpoints

### DIFF
--- a/webapp/server.py
+++ b/webapp/server.py
@@ -128,7 +128,7 @@ async def timezone_post(request: Request) -> dict:
     await _write_timezone(tz)
     return {"status": "ok"}
 
-@app.post("/profile")
+@app.post("/api/profile")
 async def save_profile(request: Request) -> dict:
     try:
         data = await request.json()
@@ -142,7 +142,7 @@ async def save_profile(request: Request) -> dict:
         raise HTTPException(status_code=400, detail="invalid data") from exc
     return {"status": "ok"}
 
-@app.get("/reminders")
+@app.get("/api/reminders")
 async def reminders_get(id: int | None = None) -> dict | list[dict]:
     async with reminders_lock:
         store = await _read_reminders()
@@ -150,7 +150,7 @@ async def reminders_get(id: int | None = None) -> dict | list[dict]:
         return list(store.values())
     return store.get(id, {})
 
-@app.post("/reminders")
+@app.post("/api/reminders")
 async def reminders_post(request: Request) -> dict:
     try:
         data = await request.json()

--- a/webapp/ui/src/api/reminders.ts
+++ b/webapp/ui/src/api/reminders.ts
@@ -5,8 +5,10 @@ export interface ReminderPayload {
   interval?: string;
 }
 
+const API_BASE = '/api';
+
 export async function updateReminder(id: string, payload: ReminderPayload) {
-  const res = await fetch(`/api/reminders/${id}`, {
+  const res = await fetch(`${API_BASE}/reminders/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
@@ -18,7 +20,7 @@ export async function updateReminder(id: string, payload: ReminderPayload) {
 }
 
 export async function createReminder(payload: ReminderPayload) {
-  const res = await fetch('/api/reminders', {
+  const res = await fetch(`${API_BASE}/reminders`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- namespace profile and reminders API routes under `/api`
- adjust client and tests for updated paths

## Testing
- `ruff check diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_6898d97c0608832aac42f2012096697d