### PR TITLE
[webapp] Align reminder update API

### DIFF
--- a/webapp/ui/src/api/reminders.ts
+++ b/webapp/ui/src/api/reminders.ts
@@ -1,4 +1,5 @@
 export interface ReminderPayload {
+  id?: number;
   type: 'sugar' | 'insulin' | 'meal' | 'medicine';
   title: string;
   time: string;
@@ -7,9 +8,9 @@ export interface ReminderPayload {
 
 const API_BASE = '/api';
 
-export async function updateReminder(id: string, payload: ReminderPayload) {
-  const res = await fetch(`${API_BASE}/reminders/${id}`, {
-    method: 'PUT',
+export async function updateReminder(payload: ReminderPayload & { id: number }) {
+  const res = await fetch(`${API_BASE}/reminders`, {
+    method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });

--- a/webapp/ui/src/pages/Reminders.tsx
+++ b/webapp/ui/src/pages/Reminders.tsx
@@ -80,7 +80,7 @@ const Reminders = () => {
   const handleSaveReminder = async (values: ReminderFormValues) => {
     try {
       if (editingReminder) {
-        await updateReminder(editingReminder.id, values);
+        await updateReminder({ id: Number(editingReminder.id), ...values });
         setReminders(prev =>
           prev.map(r =>
             r.id === editingReminder.id ? { ...r, ...values } : r


### PR DESCRIPTION
## Summary
- Update reminder API client to use POST `/api/reminders` with id for edits
- Adjust Reminders page to send id in request when editing reminders

## Testing
- `ruff check diabetes tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_6898dd81b18c832a9fdbba33125a732d