### PR TITLE
[webapp] Use theme params for colors

### DIFF
--- a/webapp/public/telegram-init.js
+++ b/webapp/public/telegram-init.js
@@ -3,18 +3,17 @@ if (window.Telegram && Telegram.WebApp) {
     webApp.ready();
     webApp.expand();
 
-    const applyLightTheme = () => {
-        webApp.setBackgroundColor('#ffffff');
-        webApp.setHeaderColor('#ffffff');
+    const applyTheme = () => {
+        const { bg_color, header_bg_color } = webApp.themeParams;
+        if (bg_color) {
+            webApp.setBackgroundColor(bg_color);
+        }
+        if (header_bg_color) {
+            webApp.setHeaderColor(header_bg_color);
+        }
     };
 
-    if (webApp.colorScheme !== 'light') {
-        applyLightTheme();
-    }
+    applyTheme();
 
-    webApp.onEvent('themeChanged', () => {
-        if (webApp.colorScheme !== 'light') {
-            applyLightTheme();
-        }
-    });
+    webApp.onEvent('themeChanged', applyTheme);
 }


### PR DESCRIPTION
## Summary
- Apply Telegram Mini App theme parameters for header and background colors
- Update theme on startup and when `themeChanged` events fire

## Testing
- `python -m pytest tests/`
- `ruff check diabetes tests`


------
https://chatgpt.com/codex/tasks/task_e_6898e64fdc68832aa98941f4b5d6bc2a