### PR TITLE
[ui] Improve modal accessibility and styling

### DIFF
--- a/webapp/ui/src/components/Modal.tsx
+++ b/webapp/ui/src/components/Modal.tsx
@@ -47,7 +47,9 @@ const Modal = ({ open, onClose, title, footer, children }: ModalProps) => {
     <div
       ref={overlayRef}
       onMouseDown={handleOverlayClick}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay)] pb-[env(safe-area-inset-bottom)]"
     >
       <div className="relative w-full max-w-lg mx-4 bg-background rounded-lg shadow-lg">
         <div className="flex items-center justify-between p-4 border-b border-border">

--- a/webapp/ui/src/index.css
+++ b/webapp/ui/src/index.css
@@ -78,11 +78,11 @@
     --warning: var(--medical-warning);
     --warning-foreground: var(--neutral-900);
     
-    --border: var(--neutral-200);
-    --input: var(--neutral-200);
-    --ring: var(--tg-theme-link-color, var(--medical-blue));
-    
-    --radius: 0.75rem;
+      --border: var(--neutral-200);
+      --input: var(--neutral-200);
+      --ring: var(--tg-theme-link-color, var(--medical-blue));
+      --overlay: hsl(var(--neutral-900) / 0.5);
+      --radius: 0.75rem;
   }
 
   /* Темная тема Telegram */
@@ -127,11 +127,12 @@
     --warning: var(--medical-warning);
     --warning-foreground: var(--neutral-900);
     
-    --border: var(--neutral-700);
-    --input: var(--neutral-700);
-    --ring: var(--tg-theme-link-color, var(--medical-teal));
+      --border: var(--neutral-700);
+      --input: var(--neutral-700);
+      --ring: var(--tg-theme-link-color, var(--medical-teal));
+      --overlay: hsl(var(--neutral-900) / 0.8);
+    }
   }
-}
 
 @layer base {
   * {


### PR DESCRIPTION
## Summary
- add `role="dialog"` and `aria-modal="true"` to Modal component
- replace hardcoded overlay color with `var(--overlay)` theme token
- support mobile safe-area with bottom padding

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype @typescript-eslint/no-empty-object-type; A `require()` style import is forbidden @typescript-eslint/no-require-imports)*
- `npx eslint src/components/Modal.tsx`
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6898e881d6a8832a8ba473a8f1c48cd7