### PR TITLE
[webapp] Improve segmented control accessibility

### DIFF
--- a/webapp/ui/src/components/SegmentedControl.tsx
+++ b/webapp/ui/src/components/SegmentedControl.tsx
@@ -1,4 +1,4 @@
-import { useId, useRef } from 'react';
+import { useRef } from 'react';
 
 export interface SegmentedItem {
   value: string;
@@ -13,11 +13,10 @@ interface SegmentedControlProps {
 }
 
 export const SegmentedControl = ({ value, onChange, items }: SegmentedControlProps) => {
-  const groupId = useId();
-  const itemRefs = useRef<HTMLLabelElement[]>([]);
+  const itemRefs = useRef<HTMLButtonElement[]>([]);
 
   const handleKeyDown = (
-    e: React.KeyboardEvent<HTMLLabelElement>,
+    e: React.KeyboardEvent<HTMLButtonElement>,
     index: number,
   ) => {
     let newIndex = index;
@@ -40,36 +39,26 @@ export const SegmentedControl = ({ value, onChange, items }: SegmentedControlPro
   };
 
   return (
-    <div className="segmented" role="radiogroup">
-      {items.map((item, index) => {
-        const id = `${groupId}-${index}`;
-        return (
-          <div className="segmented__item" key={item.value}>
-            <input
-              id={id}
-              type="radio"
-              name={groupId}
-              checked={value === item.value}
-              onChange={() => onChange(item.value)}
-            />
-            <label
-              ref={(el) => (itemRefs.current[index] = el!)}
-              htmlFor={id}
-              role="radio"
-              aria-checked={value === item.value}
-              tabIndex={value === item.value ? 0 : -1}
-              onKeyDown={(e) => handleKeyDown(e, index)}
-            >
-              {item.icon && (
-                <span className="segmented__icon">{item.icon}</span>
-              )}
-              {item.label && (
-                <span className="segmented__label">{item.label}</span>
-              )}
-            </label>
-          </div>
-        );
-      })}
+    <div className="segmented" role="group">
+      {items.map((item, index) => (
+        <div className="segmented__item" key={item.value}>
+          <button
+            ref={(el) => (itemRefs.current[index] = el!)}
+            type="button"
+            aria-pressed={value === item.value}
+            tabIndex={value === item.value ? 0 : -1}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+            onClick={() => onChange(item.value)}
+          >
+            {item.icon && (
+              <span className="segmented__icon">{item.icon}</span>
+            )}
+            {item.label && (
+              <span className="segmented__label">{item.label}</span>
+            )}
+          </button>
+        </div>
+      ))}
     </div>
   );
 };

--- a/webapp/ui/src/index.css
+++ b/webapp/ui/src/index.css
@@ -197,7 +197,7 @@
   /* Segmented control */
   .segmented {
     display: flex;
-    border: 1px solid var(--tg-theme-link-color);
+    border: 1px solid var(--primary);
     border-radius: 0.5rem;
     overflow: hidden;
   }
@@ -206,11 +206,7 @@
     flex: 1;
   }
 
-  .segmented__item input {
-    display: none;
-  }
-
-  .segmented__item label {
+  .segmented__item button {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -221,12 +217,14 @@
     background: var(--tg-theme-secondary-bg-color);
     color: var(--tg-theme-link-color);
     user-select: none;
+    width: 100%;
+    height: 100%;
+    border: 1px solid transparent;
   }
 
-  .segmented__item input:checked + label,
-  .segmented__item label[aria-checked="true"] {
-    background: var(--tg-theme-button-color);
-    color: var(--tg-theme-button-text-color);
+  .segmented__item button[aria-pressed="true"] {
+    border-color: var(--primary);
+    background: hsl(var(--medical-blue) / 0.1);
   }
 }
 


### PR DESCRIPTION
## Summary
- switch segmented control items to buttons with aria-pressed
- add primary-colored borders and active backgrounds for segments

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, A `require()` style import is forbidden)*
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6898ead6a828832a8f797f2237a2b22b