### PR TITLE
[webapp] Add optional interval to reminder form

### DIFF
--- a/webapp/ui/src/api/reminders.ts
+++ b/webapp/ui/src/api/reminders.ts
@@ -3,6 +3,7 @@ export interface ReminderPayload {
   type: 'sugar' | 'insulin' | 'meal' | 'medicine';
   title: string;
   time: string;
+  interval?: number;
 }
 
 const API_BASE = '/api';

--- a/webapp/ui/src/components/ReminderForm.tsx
+++ b/webapp/ui/src/components/ReminderForm.tsx
@@ -13,6 +13,7 @@ export interface ReminderFormValues {
   type: keyof typeof reminderTypes;
   title: string;
   time: string;
+  interval?: number;
 }
 
 interface ReminderFormProps {
@@ -26,14 +27,15 @@ const ReminderForm = ({ open, onOpenChange, initialData, onSubmit }: ReminderFor
   const [form, setForm] = useState<ReminderFormValues>({
     type: 'sugar',
     title: '',
-    time: ''
+    time: '',
+    interval: undefined
   });
 
   useEffect(() => {
     if (initialData) {
       setForm({ ...initialData });
     } else {
-      setForm({ type: 'sugar', title: '', time: '' });
+      setForm({ type: 'sugar', title: '', time: '', interval: undefined });
     }
   }, [initialData, open]);
 
@@ -116,6 +118,25 @@ const ReminderForm = ({ open, onOpenChange, initialData, onSubmit }: ReminderFor
             value={form.time}
             onChange={e => setForm(prev => ({ ...prev, time: e.target.value }))}
             className="medical-input"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-2">
+            Интервал (мин)
+          </label>
+          <input
+            type="number"
+            value={form.interval ?? ''}
+            onChange={e =>
+              setForm(prev => ({
+                ...prev,
+                interval: e.target.value ? Number(e.target.value) : undefined
+              }))
+            }
+            className="medical-input"
+            placeholder="Например: 60"
+            min={1}
           />
         </div>
       </form>

--- a/webapp/ui/src/pages/Reminders.tsx
+++ b/webapp/ui/src/pages/Reminders.tsx
@@ -14,6 +14,7 @@ interface Reminder {
   title: string;
   time: string;
   active: boolean;
+  interval?: number;
 }
 
 const reminderTypes = {


### PR DESCRIPTION
## Summary
- track interval in Reminder API payloads
- add interval numeric input and state handling to reminder form
- support interval field in reminders page types

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6898ecb48e70832a9d397e489f70f43b