### PR TITLE
[ui] Replace medical-input with form control classes

### DIFF
--- a/webapp/ui/src/components/ReminderForm.tsx
+++ b/webapp/ui/src/components/ReminderForm.tsx
@@ -84,9 +84,7 @@ const ReminderForm = ({ open, onOpenChange, initialData, onSubmit }: ReminderFor
     >
       <form id="reminder-form" onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium text-foreground mb-2">
-            Тип напоминания
-          </label>
+          <label className="form-label">Тип напоминания</label>
           <SegmentedControl
             value={form.type}
             onChange={value =>
@@ -97,34 +95,28 @@ const ReminderForm = ({ open, onOpenChange, initialData, onSubmit }: ReminderFor
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-foreground mb-2">
-            Название
-          </label>
+          <label className="form-label">Название</label>
           <input
             type="text"
             value={form.title}
             onChange={e => setForm(prev => ({ ...prev, title: e.target.value }))}
-            className="medical-input"
+            className="input"
             placeholder="Например: Измерение сахара"
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-foreground mb-2">
-            Время
-          </label>
+          <label className="form-label">Время</label>
           <input
             type="time"
             value={form.time}
             onChange={e => setForm(prev => ({ ...prev, time: e.target.value }))}
-            className="medical-input"
+            className="input"
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-foreground mb-2">
-            Интервал (мин)
-          </label>
+          <label className="form-label">Интервал (мин)</label>
           <input
             type="number"
             value={form.interval ?? ''}
@@ -134,7 +126,7 @@ const ReminderForm = ({ open, onOpenChange, initialData, onSubmit }: ReminderFor
                 interval: e.target.value ? Number(e.target.value) : undefined
               }))
             }
-            className="medical-input"
+            className="input"
             placeholder="Например: 60"
             min={1}
           />

--- a/webapp/ui/src/index.css
+++ b/webapp/ui/src/index.css
@@ -16,12 +16,6 @@ Design tokens and base styles live in styles/theme.css
            hover:shadow-[var(--shadow-medium)] transition-all duration-200;
   }
 
-  .medical-input {
-    @apply w-full px-4 py-3 bg-card border border-input rounded-xl text-foreground
-           placeholder:text-muted-foreground focus:outline-none focus:ring-2
-           focus:ring-ring focus:border-transparent transition-all duration-200;
-  }
-
   .medical-tile {
     @apply medical-card hover:bg-card/80 active:scale-95 cursor-pointer
            flex flex-col items-center justify-center min-h-[120px] text-center


### PR DESCRIPTION
## Summary
- replace `medical-input` usages with standard `.input` and `.form-label` classes in `ReminderForm`
- remove legacy `medical-input` style from `index.css`

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in textarea.tsx, @typescript-eslint/no-require-imports in tailwind.config.ts)*
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6898ff293194832aa1903c0bb7241e04