### PR TITLE
[ui] Refactor reminder cards to grid layout

### DIFF
--- a/webapp/ui/src/pages/Reminders.tsx
+++ b/webapp/ui/src/pages/Reminders.tsx
@@ -45,68 +45,64 @@ const ReminderItem = ({
       className={cn('rem-card', !reminder.active && 'opacity-60')}
       style={{ animationDelay: `${index * 100}ms` }}
     >
-      <div className="flex items-center justify-between">
-        <div className="rem-main">
-          <div
-            className={cn(
-              'w-10 h-10 rounded-lg flex items-center justify-center',
-              typeInfo.color === 'medical-error'
-                ? 'bg-medical-error/10'
-                : typeInfo.color === 'medical-blue'
-                  ? 'bg-medical-blue/10'
-                  : typeInfo.color === 'medical-success'
-                    ? 'bg-medical-success/10'
-                    : 'bg-medical-teal/10'
-            )}
-          >
-            <span className="text-lg">{typeInfo.icon}</span>
-          </div>
-          <div className="flex-1 min-w-0">
-            <h3 className="rem-title font-medium text-foreground">
-              {reminder.title}
-            </h3>
-            <div className="flex items-center gap-2 text-sm text-muted-foreground mt-1">
-              <Clock className="w-3 h-3" />
-              <span className="badge">{reminder.time}</span>
-              <span className="badge badge-tonal">{typeInfo.label}</span>
-            </div>
-          </div>
+      <div
+        className={cn(
+          'rem-left',
+          typeInfo.color === 'medical-error'
+            ? 'bg-medical-error/10'
+            : typeInfo.color === 'medical-blue'
+              ? 'bg-medical-blue/10'
+              : typeInfo.color === 'medical-success'
+                ? 'bg-medical-success/10'
+                : 'bg-medical-teal/10'
+        )}
+      >
+        <span className="text-lg">{typeInfo.icon}</span>
+      </div>
+      <div className="rem-main">
+        <h3 className="rem-title font-medium text-foreground">
+          {reminder.title}
+        </h3>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mt-1">
+          <Clock className="w-3 h-3" />
+          <span className="badge">{reminder.time}</span>
+          <span className="badge badge-tonal">{typeInfo.label}</span>
         </div>
-        <div className="rem-actions">
-          <button
-            type="button"
-            className={cn(
-              'icon-btn',
-              reminder.active
-                ? 'bg-success/10 text-success'
-                : 'bg-secondary text-muted-foreground'
-            )}
-            onClick={() => onToggle(reminder.id)}
-            aria-label={
-              reminder.active
-                ? 'Отключить напоминание'
-                : 'Включить напоминание'
-            }
-          >
-            <Bell className="w-4 h-4" />
-          </button>
-          <button
-            type="button"
-            className="icon-btn"
-            onClick={() => onEdit(reminder)}
-            aria-label="Редактировать"
-          >
-            <Edit2 className="w-4 h-4" />
-          </button>
-          <button
-            type="button"
-            className="icon-btn"
-            onClick={() => onDelete(reminder.id)}
-            aria-label="Удалить"
-          >
-            <Trash2 className="w-4 h-4" />
-          </button>
-        </div>
+      </div>
+      <div className="rem-actions">
+        <button
+          type="button"
+          className={cn(
+            'icon-btn',
+            reminder.active
+              ? 'bg-success/10 text-success'
+              : 'bg-secondary text-muted-foreground'
+          )}
+          onClick={() => onToggle(reminder.id)}
+          aria-label={
+            reminder.active
+              ? 'Отключить напоминание'
+              : 'Включить напоминание'
+          }
+        >
+          <Bell className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          className="icon-btn"
+          onClick={() => onEdit(reminder)}
+          aria-label="Редактировать"
+        >
+          <Edit2 className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          className="icon-btn"
+          onClick={() => onDelete(reminder.id)}
+          aria-label="Удалить"
+        >
+          <Trash2 className="w-4 h-4" />
+        </button>
       </div>
     </div>
   );
@@ -139,21 +135,20 @@ const Reminders = () => {
     fetchReminders();
   }, [toast]);
 
-
   const [formOpen, setFormOpen] = useState(false);
   const [editingReminder, setEditingReminder] = useState<Reminder | null>(null);
 
   const handleToggleReminder = (id: number) => {
-    setReminders(prev => 
-      prev.map(reminder => 
-        reminder.id === id 
+    setReminders(prev =>
+      prev.map(reminder =>
+        reminder.id === id
           ? { ...reminder, active: !reminder.active }
           : reminder
       )
     );
     toast({
       title: "Напоминание обновлено",
-      description: "Статус напоминания изменен"
+      description: "Статус напоминания изменен",
     });
   };
 
@@ -161,7 +156,7 @@ const Reminders = () => {
     setReminders(prev => prev.filter(reminder => reminder.id !== id));
     toast({
       title: "Напоминание удалено",
-      description: "Напоминание успешно удалено"
+      description: "Напоминание успешно удалено",
     });
   };
 
@@ -195,16 +190,16 @@ const Reminders = () => {
       toast({
         title: 'Ошибка',
         description: 'Не удалось сохранить напоминание',
-        variant: 'destructive'
+        variant: 'destructive',
       });
     }
   };
 
   return (
     <div className="min-h-screen bg-background">
-      <MedicalHeader 
-        title="Напоминания" 
-        showBack 
+      <MedicalHeader
+        title="Напоминания"
+        showBack
         onBack={() => navigate('/')}
       >
         <MedicalButton
@@ -219,86 +214,29 @@ const Reminders = () => {
           <Plus className="w-5 h-5" />
         </MedicalButton>
       </MedicalHeader>
-      
-      <main className="container mx-auto px-4 py-6">
 
+      <main className="container mx-auto px-4 py-6">
         {loading ? (
           <div className="text-center py-12">Загрузка...</div>
         ) : error ? (
           <div className="text-center py-12 text-destructive">{error}</div>
         ) : (
           <div className="space-y-3 mb-6">
-          {reminders.map((reminder, index) => {
-            const typeInfo = reminderTypes[reminder.type];
-            return (
-              <div
+            {reminders.map((reminder, index) => (
+              <ReminderItem
                 key={reminder.id}
-                className={`medical-list-item ${!reminder.active ? 'opacity-60' : ''}`}
-                style={{ animationDelay: `${index * 100}ms` }}
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3 flex-1">
-                    <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${
-                      typeInfo.color === 'medical-error' ? 'bg-medical-error/10' :
-                      typeInfo.color === 'medical-blue' ? 'bg-medical-blue/10' :
-                      typeInfo.color === 'medical-success' ? 'bg-medical-success/10' :
-                      'bg-medical-teal/10'
-                    }`}>
-                      <span className="text-lg">{typeInfo.icon}</span>
-                    </div>
-                    <div className="flex-1">
-                      <h3 className="font-medium text-foreground">{reminder.title}</h3>
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                        <Clock className="w-3 h-3" />
-                        <span>{reminder.time}</span>
-                        <span className="text-xs bg-secondary px-2 py-1 rounded">
-                          {typeInfo.label}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  <div className="flex items-center gap-2">
-                    <MedicalButton
-                      variant="icon"
-                      onClick={() => handleToggleReminder(reminder.id)}
-                      className={cn(
-                        'border-0',
-                        reminder.active
-                          ? 'bg-success/10 text-success'
-                          : 'bg-secondary text-muted-foreground'
-                      )}
-                      aria-label={reminder.active ? 'Отключить напоминание' : 'Включить напоминание'}
-                    >
-                      <Bell className="w-4 h-4" />
-                    </MedicalButton>
-                    <MedicalButton
-                      variant="icon"
-                      onClick={() => {
-                        setEditingReminder(reminder);
-                        setFormOpen(true);
-                      }}
-                      className="bg-transparent hover:bg-secondary text-muted-foreground border-0"
-                      aria-label="Редактировать"
-                    >
-                      <Edit2 className="w-4 h-4" />
-                    </MedicalButton>
-                    <MedicalButton
-                      variant="icon"
-                      onClick={() => handleDeleteReminder(reminder.id)}
-                      className="bg-transparent hover:bg-destructive/10 hover:text-destructive text-muted-foreground border-0"
-                      aria-label="Удалить"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </MedicalButton>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
+                reminder={reminder}
+                index={index}
+                onToggle={handleToggleReminder}
+                onEdit={(r) => {
+                  setEditingReminder(r);
+                  setFormOpen(true);
+                }}
+                onDelete={handleDeleteReminder}
+              />
+            ))}
           </div>
         )}
-
 
         {/* Форма создания/редактирования */}
         <ReminderForm

--- a/webapp/ui/src/styles/theme.css
+++ b/webapp/ui/src/styles/theme.css
@@ -219,19 +219,27 @@
   }
 
   .rem-card {
-    @apply bg-card border border-border rounded-lg p-4 shadow-[var(--shadow-soft)] transition-all duration-200;
+    @apply grid grid-cols-[auto_1fr_auto] items-center gap-4 bg-card border border-border rounded-lg p-4 shadow-[var(--shadow-soft)] transition-all duration-200;
+  }
+
+  .rem-left {
+    @apply w-10 h-10 rounded-lg flex items-center justify-center;
+  }
+
+  .rem-main {
+    @apply min-w-0;
   }
 
   .rem-actions {
-    @apply flex items-center gap-2;
+    @apply flex items-center gap-2 justify-self-end;
   }
 
   @media (max-width: 360px) {
     .rem-card {
-      @apply p-3;
+      @apply grid-cols-[auto_1fr] p-3;
     }
     .rem-actions {
-      @apply gap-1;
+      @apply col-span-2 mt-2 justify-self-end gap-1;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Layout reminder cards as a CSS grid with rem-left, rem-main, and rem-actions sections
- Add responsive styles to reposition actions below at narrow widths
- Style time and type labels with badge and badge-tonal classes

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6899010b2dac832ab3fc5c8a028ad9a4