### PR TITLE
[ui] Improve modal overlay and structure

### DIFF
--- a/webapp/ui/src/index.css
+++ b/webapp/ui/src/index.css
@@ -22,11 +22,16 @@ Design tokens and base styles live in styles/theme.css
            transition-all duration-200 touch-manipulation;
   }
 
-  .medical-list-item {
-    @apply bg-card border border-border rounded-lg p-4 mb-3
-           hover:shadow-[var(--shadow-soft)] transition-all duration-200;
+    .medical-list-item {
+      @apply bg-card border border-border rounded-lg p-4 mb-3
+             hover:shadow-[var(--shadow-soft)] transition-all duration-200;
+    }
+
+    .modal-card {
+      @apply relative w-full max-w-lg bg-background rounded-lg shadow-lg m-4;
+      margin-bottom: calc(1rem + env(safe-area-inset-bottom));
+    }
   }
-}
 
 @layer components {
   /* Segmented control */

--- a/webapp/ui/tailwind.config.ts
+++ b/webapp/ui/tailwind.config.ts
@@ -28,13 +28,14 @@ export default {
 			colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
-				ring: 'hsl(var(--ring))',
-				background: 'hsl(var(--background))',
-				foreground: 'hsl(var(--foreground))',
-				primary: {
-					DEFAULT: 'hsl(var(--primary))',
-					foreground: 'hsl(var(--primary-foreground))'
-				},
+                                ring: 'hsl(var(--ring))',
+                                background: 'hsl(var(--background))',
+                                foreground: 'hsl(var(--foreground))',
+                                overlay: 'hsl(var(--overlay))',
+                                primary: {
+                                        DEFAULT: 'hsl(var(--primary))',
+                                        foreground: 'hsl(var(--primary-foreground))'
+                                },
 				secondary: {
 					DEFAULT: 'hsl(var(--secondary))',
 					foreground: 'hsl(var(--secondary-foreground))'


### PR DESCRIPTION
## Summary
- wrap modal content in reusable `.modal-card` container
- add focus trapping and overlay color using theme token
- expose overlay color in Tailwind theme

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*
- `npm run build` *(fails: `@layer base` is used but no matching `@tailwind base`)*
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689903245aa8832ab9b6a05ac7f3d52e