### PR TITLE
[ui] add theme toggle

### DIFF
--- a/webapp/ui/src/App.tsx
+++ b/webapp/ui/src/App.tsx
@@ -5,6 +5,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { useTelegram } from "@/hooks/useTelegram";
+import { ThemeProvider } from "next-themes";
 import Home from "./pages/Home";
 import Profile from "./pages/Profile";
 import Reminders from "./pages/Reminders";
@@ -47,15 +48,17 @@ const AppContent = () => {
 };
 
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter basename="/ui">
-        <AppContent />
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+  <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter basename="/ui">
+          <AppContent />
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  </ThemeProvider>
 );
 
 export default App;

--- a/webapp/ui/src/components/MedicalHeader.tsx
+++ b/webapp/ui/src/components/MedicalHeader.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import ThemeToggle from '@/components/ThemeToggle';
 
 interface MedicalHeaderProps {
   title: string;
@@ -26,7 +27,10 @@ export const MedicalHeader = ({ title, showBack, onBack, children }: MedicalHead
             )}
             <h1 className="text-xl font-semibold text-foreground">{title}</h1>
           </div>
-          {children}
+          <div className="flex items-center gap-2">
+            {children}
+            <ThemeToggle />
+          </div>
         </div>
       </div>
     </header>

--- a/webapp/ui/src/components/ThemeToggle.tsx
+++ b/webapp/ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+
+import { Switch } from "@/components/ui/switch";
+
+/**
+ * ThemeToggle toggles between light and dark themes using next-themes.
+ */
+const ThemeToggle = () => {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  const isDark = theme === "dark";
+
+  return (
+    <Switch
+      checked={isDark}
+      onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
+      aria-label="Переключить тему"
+    />
+  );
+};
+
+export default ThemeToggle;
+

--- a/webapp/ui/src/components/index.ts
+++ b/webapp/ui/src/components/index.ts
@@ -1,3 +1,4 @@
 export { default as Modal } from './Modal';
 export { SegmentedControl } from './SegmentedControl';
 export { default as MedicalButton } from './MedicalButton';
+export { default as ThemeToggle } from './ThemeToggle';


### PR DESCRIPTION
## Summary
- add ThemeToggle component using next-themes and Switch UI
- wrap app with ThemeProvider and include toggle in header

## Testing
- `npm run lint` (fails: existing lint errors in textarea.tsx and tailwind.config.ts)
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689979095350832aaa7245844d571675