### PR TITLE
[ui] Simplify button default variant

### DIFF
--- a/webapp/ui/src/components/ui/button.tsx
+++ b/webapp/ui/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-gradient-to-r from-primary to-primary/90 text-primary-foreground shadow-[var(--shadow-soft)] hover:shadow-[var(--shadow-medium)] active:scale-95 disabled:shadow-none",
+          "bg-gradient-button text-primary-foreground shadow-soft hover:shadow-medium active:scale-95 disabled:shadow-none",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:


### PR DESCRIPTION
## Summary
- simplify default button gradient class to `bg-gradient-button`
- replace custom shadow variables with `shadow-soft` and `shadow-medium`

## Testing
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68998990f934832ab7c6ae12dfd584af