### PR TITLE
[ui] Add height to large button variant

### DIFF
--- a/webapp/ui/src/components/ui/button.tsx
+++ b/webapp/ui/src/components/ui/button.tsx
@@ -23,7 +23,7 @@ const buttonVariants = cva(
       size: {
         default: "h-10 px-4 py-2",
         sm: "h-9 rounded-md px-3",
-        lg: "rounded-xl px-6 py-3",
+        lg: "h-12 rounded-xl px-6 py-3 text-base",
         icon: "h-10 w-10",
       },
     },


### PR DESCRIPTION
## Summary
- set fixed h-12 height for large button size
- adjust large button text to text-base for visual balance

## Testing
- `ruff check diabetes tests`
- `pytest tests`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68998b5d55d4832aa371ef948714b5bb