### PR TITLE
[webapp] Align MedicalButton variants with Button

### DIFF
--- a/webapp/ui/src/components/MedicalButton.tsx
+++ b/webapp/ui/src/components/MedicalButton.tsx
@@ -2,21 +2,15 @@ import React from 'react';
 import { Button, type ButtonProps } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
-export interface MedicalButtonProps extends Omit<ButtonProps, 'variant'> {
-  variant?: 'primary' | 'secondary' | 'icon';
-}
+export type MedicalButtonProps = ButtonProps;
 
 const MedicalButton = React.forwardRef<HTMLButtonElement, MedicalButtonProps>(
-  ({ variant = 'primary', className, size, ...props }, ref) => {
-    const buttonVariant = variant === 'secondary' ? 'secondary' : 'default';
-    const buttonSize = variant === 'icon' ? 'icon' : size ?? 'lg';
-
+  ({ className, size = 'lg', ...props }, ref) => {
     return (
       <Button
         ref={ref}
-        variant={buttonVariant}
-        size={buttonSize}
-        className={cn(variant === 'icon' && 'rounded-lg', className)}
+        size={size}
+        className={cn(size === 'icon' && 'rounded-lg', className)}
         {...props}
       />
     );

--- a/webapp/ui/src/pages/History.tsx
+++ b/webapp/ui/src/pages/History.tsx
@@ -231,7 +231,7 @@ const History = () => {
                     
                     <div className="flex items-center gap-2">
                       <MedicalButton
-                        variant="icon"
+                        size="icon"
                         onClick={() => handleEditRecord(record)}
                         className="bg-transparent hover:bg-secondary text-muted-foreground border-0 p-1"
                         aria-label="Редактировать"
@@ -239,7 +239,7 @@ const History = () => {
                         <Edit2 className="w-3 h-3" />
                       </MedicalButton>
                       <MedicalButton
-                        variant="icon"
+                        size="icon"
                         onClick={() => handleDeleteRecord(record.id)}
                         className="bg-transparent hover:bg-destructive/10 hover:text-destructive text-muted-foreground border-0 p-1"
                         aria-label="Удалить"

--- a/webapp/ui/src/pages/Reminders.tsx
+++ b/webapp/ui/src/pages/Reminders.tsx
@@ -203,7 +203,7 @@ const Reminders = () => {
         onBack={() => navigate('/')}
       >
         <MedicalButton
-          variant="icon"
+          size="icon"
           onClick={() => {
             setEditingReminder(null);
             setFormOpen(true);


### PR DESCRIPTION
## Summary
- align MedicalButton props with Button to share variant names
- update usage to pass `size="icon"` for icon buttons

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, etc.)*
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6899919bca10832aaff2cc7caf2978ed