### PR TITLE
[ui] Add scroll lock and focus handling to Sheet

### DIFF
--- a/webapp/ui/src/components/Sheet.tsx
+++ b/webapp/ui/src/components/Sheet.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react';
+import {
+  Sheet as SheetPrimitive,
+  SheetContent,
+} from '@/components/ui/sheet';
+
+interface SheetProps {
+  open: boolean;
+  onClose: () => void;
+  side?: 'top' | 'bottom' | 'left' | 'right';
+  children: React.ReactNode;
+}
+
+const Sheet = ({ open, onClose, side = 'right', children }: SheetProps) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const previousOverflow = document.body.style.overflow;
+    const focusableSelector =
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+    const firstFocusable = contentRef.current?.querySelector<HTMLElement>(
+      focusableSelector,
+    );
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    triggerRef.current = document.activeElement as HTMLElement;
+    document.body.style.overflow = 'hidden';
+    document.addEventListener('keydown', handleKeyDown);
+    (firstFocusable || contentRef.current)?.focus();
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', handleKeyDown);
+      triggerRef.current?.focus();
+    };
+  }, [open, onClose]);
+
+  return (
+    <SheetPrimitive
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+    >
+      <SheetContent ref={contentRef} side={side} tabIndex={-1}>
+        {children}
+      </SheetContent>
+    </SheetPrimitive>
+  );
+};
+
+export default Sheet;
+

--- a/webapp/ui/src/components/index.ts
+++ b/webapp/ui/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as Modal } from './Modal';
 export { SegmentedControl } from './SegmentedControl';
 export { default as MedicalButton } from './MedicalButton';
 export { default as ThemeToggle } from './ThemeToggle';
+export { default as Sheet } from './Sheet';


### PR DESCRIPTION
## Summary
- lock body scroll and manage focus in Sheet
- export Sheet from components index

## Testing
- `ruff check diabetes tests`
- `pytest tests`
- `npm run lint` *(fails: no-empty-object-type, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689993d7da20832aa3201ba3d8c730ec