### PR TITLE
[ui] Add error handling for reminder creation

### DIFF
--- a/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/webapp/ui/src/reminders/CreateReminder.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import ReminderForm, { ReminderFormValues } from "@/components/ReminderForm";
+
+export default function CreateReminder() {
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (values: ReminderFormValues) => {
+    setError(null);
+    try {
+      const res = await fetch("/api/reminders", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values)
+      });
+      if (!res.ok) {
+        throw new Error("Failed to create reminder");
+      }
+      navigate("/reminders");
+    } catch {
+      setError("Не удалось сохранить напоминание");
+    }
+  };
+
+  return (
+    <div>
+      {error && (
+        <div className="mb-4 text-destructive">
+          {error}
+        </div>
+      )}
+      <ReminderForm onSubmit={handleSubmit} onCancel={() => navigate("/reminders")} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add CreateReminder component with try/catch around fetch
- show error messages in the UI instead of alerts and navigate on success

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; A require() style import is forbidden)*
- `npx eslint src/reminders/CreateReminder.tsx`
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689997911f14832aa0f1d8198e3ece9b