### PR TITLE
[webapp] add shared stylesheet

### DIFF
--- a/webapp/server.py
+++ b/webapp/server.py
@@ -216,6 +216,13 @@ async def ui_files(full_path: str) -> FileResponse:
         return FileResponse(target)
     return serve_index()
 
+# статика для общих HTML-форм
+@app.get("/style.css", include_in_schema=False)
+@app.head("/style.css", include_in_schema=False)
+async def style_css() -> FileResponse:
+    """Serve shared stylesheet."""
+    return FileResponse(BASE_DIR / "style.css")
+
 # -----------------------------------
 
 # редирект корня на SPA

--- a/webapp/style.css
+++ b/webapp/style.css
@@ -1,0 +1,110 @@
+/* Global typography */
+html {
+  box-sizing: border-box;
+}
+*, *::before, *::after {
+  box-sizing: inherit;
+}
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  color: #111;
+  background: #fff;
+}
+
+/* Improve contrast in dark mode */
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #eee;
+    background: #000;
+  }
+}
+
+/* Responsive form grid: stacked by default, two columns from 420px */
+form {
+  display: grid;
+  gap: 1rem;
+}
+@media (min-width: 420px) {
+  form {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Utility classes */
+.sheet {
+  background: #fff;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.type-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+}
+.type-chip.sugar {
+  background: #fdeaea;
+  color: #c53030;
+}
+.type-chip.insulin {
+  background: #eaf4ff;
+  color: #2b6cb0;
+}
+.type-chip.meal {
+  background: #e8f5e9;
+  color: #2f855a;
+}
+.type-chip.medicine {
+  background: #e6fffa;
+  color: #0b7285;
+}
+
+.sticky-actions {
+  position: sticky;
+  bottom: 0;
+  background: inherit;
+  padding: 0.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.reminder-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: #fff;
+}
+.reminder-card.sugar {
+  background: #fdeaea;
+  border-color: #fbb6b6;
+}
+.reminder-card.insulin {
+  background: #eaf4ff;
+  border-color: #90cdf4;
+}
+.reminder-card.meal {
+  background: #e8f5e9;
+  border-color: #9ae6b4;
+}
+.reminder-card.medicine {
+  background: #e6fffa;
+  border-color: #81e6d9;
+}
+
+.rem-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
## Summary
- add global CSS with typography, responsive forms, and utility classes for reminders
- expose `style.css` via FastAPI for static serving

## Testing
- `python -m pytest tests`
- `ruff check diabetes tests webapp/server.py`


------
https://chatgpt.com/codex/tasks/task_e_6899a07b137c832a8e53a6e21cc6dfad