### PR TITLE
[webapp] Force light colors for Telegram WebApp

### DIFF
--- a/webapp/public/telegram-init.js
+++ b/webapp/public/telegram-init.js
@@ -5,13 +5,8 @@
     }
 
     const applyTheme = () => {
-        const { bg_color, header_color } = app.themeParams;
-        if (bg_color) {
-            app.setBackgroundColor(bg_color);
-        }
-        if (header_color) {
-            app.setHeaderColor(header_color);
-        }
+        app.setBackgroundColor('#fff');
+        app.setHeaderColor('#fff');
     };
 
     app.expand();


### PR DESCRIPTION
## Summary
- hardcode Telegram WebApp theme to light colors and reapply on theme changes

## Testing
- `pytest tests/`
- `ruff check diabetes tests`
- `pre-commit run --files webapp/public/telegram-init.js`


------
https://chatgpt.com/codex/tasks/task_e_6899a2b8ce68832abc1a37fb280288e4