### PR TITLE
[webapp] Add theme metadata and stylesheet

### DIFF
--- a/webapp/ui/index.html
+++ b/webapp/ui/index.html
@@ -7,10 +7,14 @@
     <link rel="icon" type="image/png" href="/src/assets/app-icon.png" />
     <meta name="description" content="Умный помощник для людей с диабетом 2 типа с GPT-аналитикой еды" />
     <meta name="author" content="СахарФото" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#ffffff" />
+    <link rel="stylesheet" href="/style.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <script src="/telegram-init.js" defer></script>
 
     <meta property="og:title" content="saharlight-ux" />
     <meta property="og:description" content="Lovable Generated Project" />


### PR DESCRIPTION
## Summary
- add light color scheme and theme color meta tags
- include global stylesheet
- load Telegram init script after Telegram Web App script

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6899a506628c832a9dfacff9e3f98056