### PR TITLE
[ui] Update reminders payload

### DIFF
--- a/webapp/ui/src/api/reminders.ts
+++ b/webapp/ui/src/api/reminders.ts
@@ -1,9 +1,8 @@
 export interface ReminderPayload {
+  type: string;
+  text: string;
+  value: string;
   id?: number;
-  type: 'sugar' | 'insulin' | 'meal' | 'medicine';
-  title: string;
-  time: string;
-  interval?: number;
 }
 
 const API_BASE = '/api';
@@ -17,7 +16,7 @@ export async function getReminders() {
 }
 
 export async function updateReminder(payload: ReminderPayload & { id: number }) {
-  const res = await fetch(`${API_BASE}/reminders`, {
+  const res = await fetch(`/reminders`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ...payload, id: Number(payload.id) })
@@ -30,7 +29,7 @@ export async function updateReminder(payload: ReminderPayload & { id: number }) 
 }
 
 export async function createReminder(payload: ReminderPayload) {
-  const res = await fetch(`${API_BASE}/reminders`, {
+  const res = await fetch(`/reminders`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- align reminder payload with new type/text/value structure
- send reminder create/update requests to `/reminders`

## Testing
- `npm run lint` (fails: react-refresh, @typescript-eslint/no-empty-object-type, no-require-imports)
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6899ab118b60832a8d4c9d24ace605d4