### PR TITLE
[webapp] Route reminders to CreateReminder page

### DIFF
--- a/webapp/ui/src/App.tsx
+++ b/webapp/ui/src/App.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from "next-themes";
 import Home from "./pages/Home";
 import Profile from "./pages/Profile";
 import Reminders from "./pages/Reminders";
+import CreateReminder from "./reminders/CreateReminder";
 import History from "./pages/History";
 import NewMeasurement from "./pages/NewMeasurement";
 import NewMeal from "./pages/NewMeal";
@@ -36,7 +37,9 @@ const AppContent = () => {
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/profile" element={<Profile />} />
-      <Route path="/reminders" element={<Reminders />} />
+        <Route path="/reminders" element={<Reminders />} />
+        <Route path="/reminders/new" element={<CreateReminder />} />
+        <Route path="/reminders/:id/edit" element={<CreateReminder />} />
       <Route path="/history" element={<History />} />
       <Route path="/history/new-measurement" element={<NewMeasurement />} />
       <Route path="/history/new-meal" element={<NewMeal />} />

--- a/webapp/ui/src/pages/Reminders.tsx
+++ b/webapp/ui/src/pages/Reminders.tsx
@@ -3,8 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Plus, Clock, Edit2, Trash2, Bell } from 'lucide-react';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useToast } from '@/hooks/use-toast';
-import ReminderForm, { ReminderFormValues } from '@/components/ReminderForm';
-import { createReminder, updateReminder, getReminders } from '@/api/reminders';
+import { getReminders } from '@/api/reminders';
 import MedicalButton from '@/components/MedicalButton';
 import { cn } from '@/lib/utils';
 
@@ -37,73 +36,58 @@ const ReminderItem = ({
   index,
   onToggle,
   onEdit,
-  onDelete
+  onDelete,
 }: ReminderItemProps) => {
   const typeInfo = reminderTypes[reminder.type];
   return (
     <div
-      className={cn('rem-card', !reminder.active && 'opacity-60')}
+      className={cn('reminder-card', reminder.type, !reminder.active && 'opacity-60')}
       style={{ animationDelay: `${index * 100}ms` }}
     >
-      <div
-        className={cn(
-          'rem-left',
-          typeInfo.color === 'medical-error'
-            ? 'bg-medical-error/10'
-            : typeInfo.color === 'medical-blue'
-              ? 'bg-medical-blue/10'
-              : typeInfo.color === 'medical-success'
-                ? 'bg-medical-success/10'
-                : 'bg-medical-teal/10'
-        )}
-      >
-        <span className="text-lg">{typeInfo.icon}</span>
-      </div>
-      <div className="rem-main">
-        <h3 className="rem-title font-medium text-foreground">
-          {reminder.title}
-        </h3>
+      <span className="text-lg">{typeInfo.icon}</span>
+      <div className="flex-1 min-w-0">
+        <h3 className="rem-title font-medium text-foreground">{reminder.title}</h3>
         <div className="flex items-center gap-2 text-sm text-muted-foreground mt-1">
           <Clock className="w-3 h-3" />
           <span className="badge">{reminder.time}</span>
           <span className="badge badge-tonal">{typeInfo.label}</span>
         </div>
       </div>
-        <div className="rem-actions">
-          <MedicalButton
-            size="icon"
-            className={cn(
-              reminder.active
-                ? 'bg-success/10 text-success'
-                : 'bg-secondary text-muted-foreground'
-            )}
-            onClick={() => onToggle(reminder.id)}
-            aria-label={
-              reminder.active
-                ? 'Отключить напоминание'
-                : 'Включить напоминание'
-            }
-            variant="ghost"
-          >
-            <Bell className="w-4 h-4" />
-          </MedicalButton>
-          <MedicalButton
-            size="icon"
-            variant="ghost"
-            onClick={() => onEdit(reminder)}
-            aria-label="Редактировать"
-          >
-            <Edit2 className="w-4 h-4" />
-          </MedicalButton>
-          <MedicalButton
-            size="icon"
-            variant="destructive"
-            onClick={() => onDelete(reminder.id)}
-            aria-label="Удалить"
-          >
-            <Trash2 className="w-4 h-4" />
-          </MedicalButton>
-        </div>
+      <div className="flex items-center gap-2">
+        <MedicalButton
+          size="icon"
+          className={cn(
+            reminder.active
+              ? 'bg-success/10 text-success'
+              : 'bg-secondary text-muted-foreground'
+          )}
+          onClick={() => onToggle(reminder.id)}
+          aria-label={
+            reminder.active
+              ? 'Отключить напоминание'
+              : 'Включить напоминание'
+          }
+          variant="ghost"
+        >
+          <Bell className="w-4 h-4" />
+        </MedicalButton>
+        <MedicalButton
+          size="icon"
+          variant="ghost"
+          onClick={() => onEdit(reminder)}
+          aria-label="Редактировать"
+        >
+          <Edit2 className="w-4 h-4" />
+        </MedicalButton>
+        <MedicalButton
+          size="icon"
+          variant="destructive"
+          onClick={() => onDelete(reminder.id)}
+          aria-label="Удалить"
+        >
+          <Trash2 className="w-4 h-4" />
+        </MedicalButton>
+      </div>
     </div>
   );
 };
@@ -135,9 +119,6 @@ const Reminders = () => {
     fetchReminders();
   }, [toast]);
 
-  const [formOpen, setFormOpen] = useState(false);
-  const [editingReminder, setEditingReminder] = useState<Reminder | null>(null);
-
   const handleToggleReminder = (id: number) => {
     setReminders(prev =>
       prev.map(reminder =>
@@ -160,41 +141,6 @@ const Reminders = () => {
     });
   };
 
-  const handleSaveReminder = async (values: ReminderFormValues) => {
-    try {
-      if (editingReminder) {
-        await updateReminder({ id: editingReminder.id, ...values });
-        setReminders(prev =>
-          prev.map(r =>
-            r.id === editingReminder.id ? { ...r, ...values } : r
-          )
-        );
-        toast({
-          title: 'Напоминание обновлено',
-          description: 'Изменения сохранены'
-        });
-      } else {
-        const data = await createReminder(values);
-        setReminders(prev => [
-          ...prev,
-          { id: Number(data.id), ...values, active: true }
-        ]);
-        toast({
-          title: 'Напоминание добавлено',
-          description: 'Новое напоминание создано'
-        });
-      }
-      setFormOpen(false);
-      setEditingReminder(null);
-    } catch {
-      toast({
-        title: 'Ошибка',
-        description: 'Не удалось сохранить напоминание',
-        variant: 'destructive',
-      });
-    }
-  };
-
   return (
     <div className="min-h-screen bg-background">
       <MedicalHeader
@@ -204,10 +150,7 @@ const Reminders = () => {
       >
         <MedicalButton
           size="icon"
-          onClick={() => {
-            setEditingReminder(null);
-            setFormOpen(true);
-          }}
+          onClick={() => navigate('/reminders/new')}
           className="bg-primary text-primary-foreground hover:bg-primary/90 border-0"
           aria-label="Добавить напоминание"
         >
@@ -228,27 +171,12 @@ const Reminders = () => {
                 reminder={reminder}
                 index={index}
                 onToggle={handleToggleReminder}
-                onEdit={(r) => {
-                  setEditingReminder(r);
-                  setFormOpen(true);
-                }}
+                onEdit={(r) => navigate(`/reminders/${r.id}/edit`)}
                 onDelete={handleDeleteReminder}
               />
             ))}
           </div>
         )}
-
-        {/* Форма создания/редактирования */}
-        <ReminderForm
-          open={formOpen}
-          onOpenChange={(open) => {
-            setFormOpen(open);
-            if (!open) setEditingReminder(null);
-          }}
-          initialData={editingReminder || undefined}
-          onSubmit={handleSaveReminder}
-        />
-
         {/* Пустое состояние */}
         {!loading && !error && reminders.length === 0 && (
           <div className="text-center py-12">
@@ -259,13 +187,7 @@ const Reminders = () => {
             <p className="text-muted-foreground mb-6">
               Добавьте первое напоминание для контроля диабета
             </p>
-            <MedicalButton
-              onClick={() => {
-                setEditingReminder(null);
-                setFormOpen(true);
-              }}
-              size="lg"
-            >
+            <MedicalButton onClick={() => navigate('/reminders/new')} size="lg">
               Создать напоминание
             </MedicalButton>
           </div>

--- a/webapp/ui/src/styles/theme.css
+++ b/webapp/ui/src/styles/theme.css
@@ -222,28 +222,27 @@
     @apply bg-muted text-muted-foreground;
   }
 
-  .rem-card {
-    @apply grid grid-cols-[auto_1fr_auto] items-center gap-4 bg-card border border-border rounded-lg p-4 shadow-[var(--shadow-soft)] transition-all duration-200;
+  .reminder-card {
+    @apply flex items-center gap-3 p-3 rounded-lg border bg-card;
   }
 
-  .rem-left {
-    @apply w-10 h-10 rounded-lg flex items-center justify-center;
+  .reminder-card.sugar {
+    @apply bg-medical-error/10 border-medical-error/20;
   }
 
-  .rem-main {
-    @apply min-w-0;
+  .reminder-card.insulin {
+    @apply bg-medical-blue/10 border-medical-blue/20;
   }
 
-  .rem-actions {
-    @apply flex items-center gap-2 justify-self-end;
+  .reminder-card.meal {
+    @apply bg-medical-success/10 border-medical-success/20;
   }
 
-  @media (max-width: 360px) {
-    .rem-card {
-      @apply grid-cols-[auto_1fr] p-3;
-    }
-    .rem-actions {
-      @apply col-span-2 mt-2 justify-self-end gap-1;
-    }
+  .reminder-card.medicine {
+    @apply bg-medical-teal/10 border-medical-teal/20;
+  }
+
+  .rem-title {
+    @apply truncate;
   }
 }


### PR DESCRIPTION
## Summary
- replace ReminderForm with routing to CreateReminder
- apply compact reminder-card layout with ellipsis
- add reminder routes and editing support

## Testing
- `npm run lint` (fails: react-refresh warnings, no-empty-object-type, no-require-imports)
- `ruff check diabetes tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6899ac2bc280832a90b9c23f5ff24b2e