### PR TITLE
[db] add async run_db helper and refactor handlers

### DIFF
--- a/diabetes/profile_handlers.py
+++ b/diabetes/profile_handlers.py
@@ -438,7 +438,9 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 .first()
             )
             if alert:
-                evaluate_sugar(user_id, alert.sugar, context.application.job_queue)
+                await evaluate_sugar(
+                    user_id, alert.sugar, context.application.job_queue
+                )
 
         low = profile.low_threshold or 0
         high = profile.high_threshold or 0

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -47,7 +47,7 @@ async def test_threshold_evaluation():
         session.commit()
 
     job_queue_low = DummyJobQueue()
-    handlers.evaluate_sugar(1, 3, job_queue_low)
+    await handlers.evaluate_sugar(1, 3, job_queue_low)
     with TestSession() as session:
         alert = session.query(Alert).filter_by(user_id=1).first()
         assert alert.type == "hypo"
@@ -55,7 +55,7 @@ async def test_threshold_evaluation():
     assert job_queue_low.jobs[0].when == handlers.ALERT_REPEAT_DELAY
 
     job_queue_high = DummyJobQueue()
-    handlers.evaluate_sugar(2, 9, job_queue_high)
+    await handlers.evaluate_sugar(2, 9, job_queue_high)
     with TestSession() as session:
         alert2 = session.query(Alert).filter_by(user_id=2).first()
         assert alert2.type == "hyper"
@@ -76,7 +76,7 @@ async def test_repeat_logic():
         session.commit()
 
     job_queue = DummyJobQueue()
-    handlers.evaluate_sugar(1, 3, job_queue)
+    await handlers.evaluate_sugar(1, 3, job_queue)
 
     for i in range(1, 4):
         context = SimpleNamespace(job=SimpleNamespace(data={"user_id": 1, "count": i}), job_queue=job_queue)
@@ -99,10 +99,10 @@ async def test_normal_reading_resolves_alert():
         session.commit()
 
     job_queue = DummyJobQueue()
-    handlers.evaluate_sugar(1, 3, job_queue)
+    await handlers.evaluate_sugar(1, 3, job_queue)
     assert job_queue.jobs
 
-    handlers.evaluate_sugar(1, 5, job_queue)
+    await handlers.evaluate_sugar(1, 5, job_queue)
     with TestSession() as session:
         alert = session.query(Alert).filter_by(user_id=1).first()
         assert alert.resolved

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -92,7 +92,7 @@ async def test_profile_security_threshold_changes(monkeypatch, action, expected_
 
     calls = []
 
-    def fake_eval(user_id, sugar, job_queue):
+    async def fake_eval(user_id, sugar, job_queue):
         calls.append((user_id, sugar, job_queue))
 
     monkeypatch.setattr(handlers, "evaluate_sugar", fake_eval)
@@ -137,7 +137,7 @@ async def test_profile_security_toggle_sos_alerts(monkeypatch):
 
     calls = []
 
-    def fake_eval(user_id, sugar, job_queue):
+    async def fake_eval(user_id, sugar, job_queue):
         calls.append((user_id, sugar, job_queue))
 
     monkeypatch.setattr(handlers, "evaluate_sugar", fake_eval)

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -154,7 +154,8 @@ def test_render_reminders_formatting(monkeypatch):
             ]
         )
         session.commit()
-    text, markup = handlers._render_reminders(1)
+    with TestSession() as session:
+        text, markup = handlers._render_reminders(session, 1)
     header, *rest = text.splitlines()
     assert header == "Ваши напоминания  (2 / 1 🔔) ⚠️"
     assert "⏰ По времени" in text
@@ -175,7 +176,8 @@ def test_render_reminders_no_webapp(monkeypatch):
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar", time="08:00", is_enabled=True))
         session.commit()
-    text, markup = handlers._render_reminders(1)
+    with TestSession() as session:
+        text, markup = handlers._render_reminders(session, 1)
     assert "Нажмите кнопку" not in text
     assert len(markup.inline_keyboard) == 1
     texts = [btn.text for btn in markup.inline_keyboard[0]]


### PR DESCRIPTION
## Summary
- add `run_db` helper to execute blocking database work in a background thread
- refactor reminder handlers to use `run_db` for session management
- make alert evaluation async and run database operations via `run_db`

## Testing
- `ruff check diabetes tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6899b80718b8832a98acce17cd502dd4