### PR TITLE
[alerts] notify from evaluate_sugar

### DIFF
--- a/diabetes/alert_handlers.py
+++ b/diabetes/alert_handlers.py
@@ -25,11 +25,40 @@ def schedule_alert(user_id: int, job_queue, count: int = 1) -> None:
     )
 
 
-async def evaluate_sugar(user_id: int, sugar: float, job_queue) -> None:
+async def _send_alert_message(
+    user_id: int,
+    sugar: float,
+    profile_info: dict,
+    context: ContextTypes.DEFAULT_TYPE,
+    first_name: str,
+) -> None:
+    coords, link = await get_coords_and_link()
+    msg = f"⚠️ У {first_name} критический сахар {sugar} ммоль/л. {coords} {link}"
+    await context.bot.send_message(chat_id=user_id, text=msg)
+    if profile_info.get("sos_contact") and profile_info.get("sos_alerts_enabled"):
+        contact = profile_info["sos_contact"]
+        if contact.startswith("@"):
+            await context.bot.send_message(chat_id=contact, text=msg)
+        else:
+            logger.info(
+                "SOS contact '%s' is not a Telegram username; skipping", contact
+            )
+
+
+async def evaluate_sugar(
+    user_id: int,
+    sugar: float,
+    job_queue=None,
+    *,
+    context: ContextTypes.DEFAULT_TYPE | None = None,
+    first_name: str = "",
+) -> None:
     def db_eval(session):
         profile = session.get(Profile, user_id)
-        low = profile.low_threshold if profile else None
-        high = profile.high_threshold if profile else None
+        if not profile:
+            return False, None
+        low = profile.low_threshold
+        high = profile.high_threshold
 
         active = (
             session.query(Alert)
@@ -43,43 +72,6 @@ async def evaluate_sugar(user_id: int, sugar: float, job_queue) -> None:
             session.add(alert)
             if not commit_session(session):
                 return False, None
-            return True, "schedule"
-        else:
-            for a in active:
-                a.resolved = True
-            if not commit_session(session):
-                return False, None
-            return True, "remove"
-
-    ok, action = await run_db(db_eval, sessionmaker=SessionLocal)
-    if not ok:
-        return
-    if action == "schedule":
-        schedule_alert(user_id, job_queue)
-    else:
-        for job in job_queue.get_jobs_by_name(f"alert_{user_id}"):
-            job.schedule_removal()
-
-
-async def check_alert(update, context: ContextTypes.DEFAULT_TYPE, sugar: float) -> None:
-    """Evaluate sugar reading, record alerts, and notify if needed."""
-    user_id = update.effective_user.id
-    with SessionLocal() as session:
-        profile = session.get(Profile, user_id)
-        if not profile:
-            return
-        low = profile.low_threshold
-        high = profile.high_threshold
-        atype = None
-        if low is not None and sugar < low:
-            atype = "hypo"
-        elif high is not None and sugar > high:
-            atype = "hyper"
-        if atype:
-            alert = Alert(user_id=user_id, sugar=sugar, type=atype)
-            session.add(alert)
-            if not commit_session(session):
-                return
             alerts = (
                 session.query(Alert)
                 .filter_by(user_id=user_id, resolved=False)
@@ -87,31 +79,54 @@ async def check_alert(update, context: ContextTypes.DEFAULT_TYPE, sugar: float) 
                 .limit(3)
                 .all()
             )
-            if len(alerts) == 3 and all(a.type == atype for a in alerts):
-                coords, link = await get_coords_and_link()
-                first_name = update.effective_user.first_name or ""
-                msg = (
-                    f"⚠️ У {first_name} критический сахар {sugar} ммоль/л. {coords} {link}"
-                )
-                await context.bot.send_message(chat_id=user_id, text=msg)
-                if profile.sos_contact and profile.sos_alerts_enabled:
-                    if profile.sos_contact.startswith("@"):
-                        await context.bot.send_message(
-                            chat_id=profile.sos_contact, text=msg
-                        )
-                    else:
-                        logger.info(
-                            "SOS contact '%s' is not a Telegram username; skipping",
-                            profile.sos_contact,
-                        )
+            notify = len(alerts) == 3 and all(a.type == atype for a in alerts)
+            if notify:
                 for a in alerts:
                     a.resolved = True
                 commit_session(session)
+            return True, {
+                "action": "schedule",
+                "notify": notify,
+                "profile": {
+                    "sos_contact": profile.sos_contact,
+                    "sos_alerts_enabled": profile.sos_alerts_enabled,
+                },
+            }
         else:
-            session.query(Alert).filter_by(user_id=user_id, resolved=False).update(
-                {"resolved": True}
-            )
-            commit_session(session)
+            for a in active:
+                a.resolved = True
+            if not commit_session(session):
+                return False, None
+            return True, {"action": "remove", "notify": False}
+
+    ok, result = await run_db(db_eval, sessionmaker=SessionLocal)
+    if not ok or result is None:
+        return
+    action = result["action"]
+    if action == "schedule" and job_queue is not None:
+        schedule_alert(user_id, job_queue)
+    elif action == "remove" and job_queue is not None:
+        for job in job_queue.get_jobs_by_name(f"alert_{user_id}"):
+            job.schedule_removal()
+
+    if result.get("notify") and context is not None:
+        await _send_alert_message(
+            user_id, sugar, result.get("profile", {}), context, first_name
+        )
+
+
+async def check_alert(update, context: ContextTypes.DEFAULT_TYPE, sugar: float) -> None:
+    """Wrapper to evaluate sugar using :func:`evaluate_sugar`."""
+    job_queue = getattr(context, "job_queue", None)
+    if job_queue is None:
+        job_queue = getattr(getattr(context, "application", None), "job_queue", None)
+    await evaluate_sugar(
+        update.effective_user.id,
+        sugar,
+        job_queue,
+        context=context,
+        first_name=update.effective_user.first_name or "",
+    )
 
 
 async def alert_job(context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- Centralize alert notifications and SOS contact handling
- Make `evaluate_sugar` send alerts and reuse it from `check_alert`

## Testing
- `ruff check diabetes tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899d6ce9158832a86fb7747c0a075ac