### PR TITLE
Use structured logging for GPT parse

### DIFF
--- a/gpt_command_parser.py
+++ b/gpt_command_parser.py
@@ -73,7 +73,7 @@ async def parse_command(text: str) -> dict | None:
             logging.error("OpenAI completion returned no choices")
             return None
         content = choices[0].message.content.strip()
-        logging.info(f"GPT parse response: {content}")
+        logging.info("GPT parse response: %s", content)
         try:
             return json.loads(content)
         except json.JSONDecodeError:


### PR DESCRIPTION
## Summary
- log GPT parse responses with argument-style formatting to avoid eager interpolation

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689c0a59a930832a8c8094010d8269da