### PR TITLE
Annotate nutrition extraction return

### DIFF
--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,8 +1,12 @@
 import re
 
 
-def extract_nutrition_info(text: str):
-    """Parse carbs and XE values from Vision text."""
+def extract_nutrition_info(text: str) -> tuple[float | None, float | None]:
+    """Parse carbs and XE values from Vision text.
+
+    Returns a tuple ``(carbs, xe)`` where either value may be ``None`` if it
+    could not be determined from ``text``.
+    """
     carbs = xe = None
 
     m = re.search(r"углевод[^\d]*:\s*([\d.,]+)\s*г", text, re.IGNORECASE)


### PR DESCRIPTION
## Summary
- type `extract_nutrition_info` to return optional carb and XE values
- document that carb/XE may be `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c0b2c5df8832a8faef4e5d8745513