### PR TITLE
Ensure logging setup resets existing handlers

### DIFF
--- a/bot/startup.py
+++ b/bot/startup.py
@@ -11,6 +11,7 @@ def setup() -> logging.Logger:
             logging.FileHandler("bot.log"),
             logging.StreamHandler(),
         ],
+        force=True,
     )
     logger = logging.getLogger("bot")
 


### PR DESCRIPTION
## Summary
- Reset bot logger configuration with `force=True` to replace any existing handlers

## Testing
- `pytest -q` *(fails: Missing required environment variables: DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD)*

------
https://chatgpt.com/codex/tasks/task_e_689c11647048832a8d949d0a035ad61a