### PR TITLE
Make protocol field required in diagnosis response

### DIFF
--- a/api.py
+++ b/api.py
@@ -8,7 +8,7 @@ class DiagnoseRequest(BaseModel):
     diagnosis: str
 
 class DiagnoseResponse(BaseModel):
-    protocol: str | None
+    protocol: str
 
 @app.post("/v1/ai/diagnose", response_model=DiagnoseResponse)
 async def ai_diagnose(req: DiagnoseRequest) -> DiagnoseResponse:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,11 +1,13 @@
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
-from api import ai_diagnose, DiagnoseRequest
+from api import ai_diagnose, DiagnoseRequest, DiagnoseResponse
 
 @pytest.mark.asyncio
 async def test_ai_diagnose_with_protocol():
     result = await ai_diagnose(DiagnoseRequest(diagnosis="диабет 2 типа"))
+    assert isinstance(result.protocol, str)
     assert result.protocol == "standard protocol"
 
 @pytest.mark.asyncio
@@ -14,4 +16,9 @@ async def test_ai_diagnose_unknown_diagnosis_returns_404():
         await ai_diagnose(DiagnoseRequest(diagnosis="unknown"))
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Protocol not found"
+
+
+def test_diagnose_response_requires_protocol():
+    with pytest.raises(ValidationError):
+        DiagnoseResponse(protocol=None)
 


### PR DESCRIPTION
## Summary
- make `protocol` field in `DiagnoseResponse` required by removing `None` from type
- extend API tests to verify `protocol` is a non-null string and absent protocol raises validation error

## Testing
- `pytest tests/test_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c12a58180832abc3ea039153d87e6