### PR TITLE
Add viewport meta tag for responsive scaling

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -16,6 +16,7 @@
   </script>
   <meta name="color-scheme" content="light" />
   <meta name="theme-color" content="#ffffff" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="style.css" />
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <script defer src="telegram-init.js"></script>


### PR DESCRIPTION
## Summary
- ensure webapp scales on mobile devices by adding viewport meta tag before CSS

## Testing
- `pip install -r requirements.txt -r requirements-test.txt`
- `DB_HOST=localhost DB_PORT=5432 DB_NAME=test DB_USER=user DB_PASSWORD=pass TELEGRAM_TOKEN=x OPENAI_API_KEY=x OPENAI_ASSISTANT_ID=x pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f3fb73084832a9dd51af749ddf5d4