### PR TITLE
Serve webapp with FastAPI StaticFiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,5 @@ DB_PORT=5432
 DB_NAME=diabetes_bot
 DB_USER=diabetes_user
 DB_PASSWORD=
-WEBAPP_URL=
+WEBAPP_URL=https://example.com/
 WEBAPP_VERSION=

--- a/api.py
+++ b/api.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from services import find_protocol_by_diagnosis
 
@@ -16,4 +17,8 @@ async def ai_diagnose(req: DiagnoseRequest) -> DiagnoseResponse:
     if protocol is None:
         raise HTTPException(status_code=404, detail="Protocol not found")
     return DiagnoseResponse(protocol=protocol)
+
+
+# Serve the Telegram WebApp static files
+app.mount("/", StaticFiles(directory="webapp", html=True), name="webapp")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,9 @@ import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
 
-from api import ai_diagnose, DiagnoseRequest, DiagnoseResponse
+from fastapi.testclient import TestClient
+
+from api import ai_diagnose, DiagnoseRequest, DiagnoseResponse, app
 
 @pytest.mark.asyncio
 async def test_ai_diagnose_with_protocol():
@@ -21,4 +23,11 @@ async def test_ai_diagnose_unknown_diagnosis_returns_404():
 def test_diagnose_response_requires_protocol():
     with pytest.raises(ValidationError):
         DiagnoseResponse(protocol=None)
+
+
+def test_webapp_served_index_html():
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Diabetes Assistant WebApp" in response.text
 


### PR DESCRIPTION
## Summary
- Serve the `webapp` directory via FastAPI using `StaticFiles`
- Provide example `WEBAPP_URL` in `.env.example`
- Test that the root path serves the WebApp index page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f43aabbd4832ab4a0fedc8d4edee7