### PR TITLE
Add tests for build_webapp_url

### DIFF
--- a/tests/test_webapp_url.py
+++ b/tests/test_webapp_url.py
@@ -1,0 +1,29 @@
+import importlib
+
+
+def load_handlers(monkeypatch, url: str, version: str):
+    monkeypatch.setenv("WEBAPP_URL", url)
+    monkeypatch.setenv("WEBAPP_VERSION", version)
+    # Required for module import
+    monkeypatch.setenv("TELEGRAM_TOKEN", "token")
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.setenv("OPENAI_ASSISTANT_ID", "assistant")
+    monkeypatch.setenv("DB_HOST", "localhost")
+    monkeypatch.setenv("DB_PORT", "5432")
+    monkeypatch.setenv("DB_NAME", "db")
+    monkeypatch.setenv("DB_USER", "user")
+    monkeypatch.setenv("DB_PASSWORD", "pass")
+    import bot.handlers as handlers
+    return importlib.reload(handlers)
+
+
+def test_build_webapp_url_without_query(monkeypatch):
+    handlers = load_handlers(monkeypatch, "https://example.com/app", "123")
+    assert handlers.build_webapp_url() == "https://example.com/app?v=123"
+
+
+def test_build_webapp_url_with_query(monkeypatch):
+    handlers = load_handlers(
+        monkeypatch, "https://example.com/app?foo=bar", "456"
+    )
+    assert handlers.build_webapp_url() == "https://example.com/app?foo=bar&v=456"


### PR DESCRIPTION
## Summary
- add tests ensuring build_webapp_url appends version query parameter properly

## Testing
- `pytest tests/test_webapp_url.py`


------
https://chatgpt.com/codex/tasks/task_e_689f499bec6c832ab9193063b5311294