### PR TITLE
Improve Telegram WebApp init fallback

### DIFF
--- a/webapp/telegram-init.js
+++ b/webapp/telegram-init.js
@@ -1,4 +1,4 @@
-const tg = window.Telegram?.WebApp;
+const tg = window.Telegram && window.Telegram.WebApp;
 if (tg) {
   try {
     tg.ready();
@@ -13,6 +13,8 @@ if (tg) {
   } catch (e) {
     console.warn('Telegram WebApp init override failed:', e);
   }
+} else {
+  console.error('Telegram WebApp not found.');
 }
 
 document.body.classList.add('light-theme');


### PR DESCRIPTION
## Summary
- replace optional chaining with explicit checks for Telegram WebApp
- log a clear error when Telegram WebApp is unavailable

## Testing
- `npm run build:clean && npm run build`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f5b085ae0832a93b412db55b84b60