### PR TITLE
Refactor command parser init

### DIFF
--- a/bot/startup.py
+++ b/bot/startup.py
@@ -1,5 +1,6 @@
 import logging
 from config import validate_tokens
+from gpt_command_parser import init_command_parser
 
 
 def setup() -> logging.Logger:
@@ -16,6 +17,7 @@ def setup() -> logging.Logger:
     logger = logging.getLogger("bot")
 
     validate_tokens()
+    init_command_parser()
 
     for name in ("httpcore", "httpx", "telegram", "telegram.ext"):
         logging.getLogger(name).setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary
- move token validation and OpenAI client setup for the command parser into a new `init_command_parser` function
- require explicit initialization before parsing commands and wire it up during bot startup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5f7077fc832aba77ab5064fd9d59